### PR TITLE
V1.2b enhance tests, add `Remark` and `DeleteCommand` related tests

### DIFF
--- a/src/main/java/seedu/realodex/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/DeleteCommand.java
@@ -84,6 +84,7 @@ public class DeleteCommand extends Command {
         if (targetIndex != null) {
             return targetIndex.equals(otherDeleteCommand.targetIndex);
         } else {
+            assert targetName != null;
             return targetName.equals(otherDeleteCommand.targetName);
         }
     }

--- a/src/main/java/seedu/realodex/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/DeleteCommand.java
@@ -84,7 +84,6 @@ public class DeleteCommand extends Command {
         if (targetIndex != null) {
             return targetIndex.equals(otherDeleteCommand.targetIndex);
         } else {
-            assert targetName != null;
             return targetName.equals(otherDeleteCommand.targetName);
         }
     }

--- a/src/main/java/seedu/realodex/model/remark/Remark.java
+++ b/src/main/java/seedu/realodex/model/remark/Remark.java
@@ -21,12 +21,15 @@ public class Remark {
         this.remarkName = remarkName;
     }
 
-    /**
-     * Returns true if a given string is a valid name.
-     * However, as of v1.2 there is no concrete check; hence it will always return true.
-     * @param test
-     * @return
-     */
+ /**
+ * Validates if the given string is a valid remark. In the current implementation (as of v1.2),
+ * this method does not perform any actual validation checks and will always return true.
+ * This is a placeholder implementation and may change in future versions.
+ *
+ * @param test the string to be validated as a remark. Cannot be null.
+ * @return always true in the current version.
+ * @throws NullPointerException if the test parameter is null.
+ */
     public static boolean isValidRemark(String test) {
         requireNonNull(test);
         return true;

--- a/src/main/java/seedu/realodex/model/remark/Remark.java
+++ b/src/main/java/seedu/realodex/model/remark/Remark.java
@@ -1,5 +1,7 @@
 package seedu.realodex.model.remark;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents a remark in realodex.
  */
@@ -15,7 +17,19 @@ public class Remark {
      * @param remarkName A valid remark.
      */
     public Remark(String remarkName) {
+        requireNonNull(remarkName);
         this.remarkName = remarkName;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     * However, as of v1.2 there is no concrete check; hence it will always return true.
+     * @param test
+     * @return
+     */
+    public static boolean isValidRemark(String test) {
+        requireNonNull(test);
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/realodex/model/remark/Remark.java
+++ b/src/main/java/seedu/realodex/model/remark/Remark.java
@@ -21,15 +21,15 @@ public class Remark {
         this.remarkName = remarkName;
     }
 
- /**
- * Validates if the given string is a valid remark. In the current implementation (as of v1.2),
- * this method does not perform any actual validation checks and will always return true.
- * This is a placeholder implementation and may change in future versions.
- *
- * @param test the string to be validated as a remark. Cannot be null.
- * @return always true in the current version.
- * @throws NullPointerException if the test parameter is null.
- */
+    /**
+     * Validates if the given string is a valid remark. In the current implementation (as of v1.2),
+     * this method does not perform any actual validation checks and will always return true.
+     * This is a placeholder implementation and may change in future versions.
+     *
+     * @param test the string to be validated as a remark. Cannot be null.
+     * @return always true in the current version.
+     * @throws NullPointerException if the test parameter is null.
+    */
     public static boolean isValidRemark(String test) {
         requireNonNull(test);
         return true;

--- a/src/test/java/seedu/realodex/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/realodex/logic/commands/CommandTestUtil.java
@@ -80,7 +80,9 @@ public class CommandTestUtil {
                 .withEmail(VALID_EMAIL_AMY)
                 .withAddress(VALID_ADDRESS_AMY)
                 .withFamily(VALID_FAMILY_AMY)
-                .withTags(VALID_TAG_BOB).build();
+                .withTags(VALID_TAG_BOB)
+                .withRemark(VALID_REMARK_AMY)
+                .build();
         DESC_BOB = new EditPersonDescriptorBuilder()
                 .withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB)
@@ -88,7 +90,9 @@ public class CommandTestUtil {
                 .withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB)
                 .withFamily(VALID_FAMILY_BOB)
-                .withTags(VALID_TAG_AMY, VALID_TAG_BOB).build();
+                .withTags(VALID_TAG_AMY, VALID_TAG_BOB)
+                .withRemark(VALID_REMARK_BOB)
+                .build();
     }
 
     /**

--- a/src/test/java/seedu/realodex/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/realodex/logic/commands/EditPersonDescriptorTest.java
@@ -9,6 +9,7 @@ import static seedu.realodex.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_AMY;
 
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,10 @@ public class EditPersonDescriptorTest {
 
         // different tags -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_AMY).build();
+        assertFalse(DESC_AMY.equals(editedAmy));
+
+        //different remarks -> returns false
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withRemark(VALID_REMARK_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/seedu/realodex/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/AddCommandParserTest.java
@@ -22,6 +22,7 @@ import static seedu.realodex.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.realodex.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.realodex.logic.commands.CommandTestUtil.REMARK_DESC_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.REMARK_DESC_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.TAG_DESC_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.TAG_DESC_BOB;
@@ -39,8 +40,10 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_FAMILY;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_INCOME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.realodex.testutil.TypicalPersons.AMY;
 import static seedu.realodex.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
@@ -99,7 +102,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + INCOME_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + FAMILY_DESC_BOB + TAG_DESC_BOB;
+                + ADDRESS_DESC_BOB + FAMILY_DESC_BOB + TAG_DESC_BOB + REMARK_DESC_BOB;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
@@ -125,13 +128,17 @@ public class AddCommandParserTest {
         assertParseFailure(parser, FAMILY_DESC_AMY + validExpectedPersonString,
                            Messages.getErrorMessageForDuplicatePrefixes(PREFIX_FAMILY));
 
+        //multiple remarks
+        assertParseFailure(parser, REMARK_DESC_AMY + validExpectedPersonString,
+                           Messages.getErrorMessageForDuplicatePrefixes(PREFIX_REMARK));
+
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedPersonString + PHONE_DESC_AMY + INCOME_DESC_AMY + EMAIL_DESC_AMY
-                        + NAME_DESC_AMY + ADDRESS_DESC_AMY + FAMILY_DESC_AMY
+                        + NAME_DESC_AMY + ADDRESS_DESC_AMY + FAMILY_DESC_AMY + REMARK_DESC_AMY
                         + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_INCOME, PREFIX_ADDRESS, PREFIX_EMAIL,
-                                                             PREFIX_PHONE, PREFIX_FAMILY));
+                                                             PREFIX_PHONE, PREFIX_FAMILY, PREFIX_REMARK));
 
         // invalid value followed by valid value
 
@@ -237,6 +244,18 @@ public class AddCommandParserTest {
                            VALID_NAME_BOB + VALID_PHONE_BOB + INCOME_DESC_BOB
                                    + VALID_EMAIL_BOB + VALID_ADDRESS_BOB + FAMILY_DESC_BOB + VALID_TAG_BOB,
                 expectedMessage);
+    }
+
+    @Test
+    public void parse_optionalFieldMissing_success() {
+        Person expectedPerson = new PersonBuilder(BOB).withRemark("").build();
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INCOME_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + FAMILY_DESC_BOB
+                + TAG_DESC_BOB, new AddCommand(expectedPerson));
+
+        expectedPerson = new PersonBuilder(AMY).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + INCOME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + FAMILY_DESC_AMY
+                + TAG_DESC_AMY, new AddCommand(expectedPerson));
+
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/AddCommandParserTest.java
@@ -249,11 +249,21 @@ public class AddCommandParserTest {
     @Test
     public void parse_optionalFieldMissing_success() {
         Person expectedPerson = new PersonBuilder(BOB).withRemark("").build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INCOME_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + FAMILY_DESC_BOB
+        assertParseSuccess(parser, NAME_DESC_BOB
+                + PHONE_DESC_BOB
+                + INCOME_DESC_BOB
+                + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB
+                + FAMILY_DESC_BOB
                 + TAG_DESC_BOB, new AddCommand(expectedPerson));
 
         expectedPerson = new PersonBuilder(AMY).build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + INCOME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + FAMILY_DESC_AMY
+        assertParseSuccess(parser, NAME_DESC_AMY
+                + PHONE_DESC_AMY
+                + INCOME_DESC_AMY
+                + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY
+                + FAMILY_DESC_AMY
                 + TAG_DESC_AMY, new AddCommand(expectedPerson));
     }
 

--- a/src/test/java/seedu/realodex/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/AddCommandParserTest.java
@@ -255,7 +255,6 @@ public class AddCommandParserTest {
         expectedPerson = new PersonBuilder(AMY).build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + INCOME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + FAMILY_DESC_AMY
                 + TAG_DESC_AMY, new AddCommand(expectedPerson));
-
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/DeleteCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.realodex.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.realodex.logic.commands.DeleteCommand;
+import seedu.realodex.model.person.Name;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -21,8 +22,13 @@ public class DeleteCommandParserTest {
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
+    public void parse_validIndex_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_validName_returnsDeleteCommand() {
+        assertParseSuccess(parser, " n/James", new DeleteCommand(new Name("James")));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/DeleteCommandParserTest.java
@@ -4,10 +4,12 @@ import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseFailu
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.realodex.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.realodex.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.realodex.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.realodex.logic.commands.DeleteCommand;
+import seedu.realodex.logic.parser.exceptions.ParseException;
 import seedu.realodex.model.person.Name;
 
 /**
@@ -29,6 +31,13 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validName_returnsDeleteCommand() {
         assertParseSuccess(parser, " n/James", new DeleteCommand(new Name("James")));
+    }
+
+    @Test
+    public void parse_invalidName_throwParseException() {
+        assertThrows(ParseException.class, Name.MESSAGE_CONSTRAINTS, () -> parser.parse(" n/peter*"));
+        assertThrows(ParseException.class, Name.MESSAGE_CONSTRAINTS, () -> parser.parse(" n/ "));
+        assertThrows(ParseException.class, Name.MESSAGE_CONSTRAINTS, () -> parser.parse(" n/^"));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/DeleteCommandParserTest.java
@@ -3,8 +3,8 @@ package seedu.realodex.logic.parser;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.realodex.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.realodex.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.realodex.testutil.Assert.assertThrows;
+import static seedu.realodex.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
@@ -19,6 +19,7 @@ import static seedu.realodex.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.REMARK_DESC_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.REMARK_DESC_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.TAG_DESC_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.TAG_DESC_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
@@ -30,6 +31,7 @@ import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_BOB;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_ADDRESS;
@@ -37,6 +39,7 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_FAMILY;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_INCOME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -132,7 +135,8 @@ public class EditCommandParserTest {
                 + ADDRESS_DESC_AMY
                 + NAME_DESC_AMY
                 + FAMILY_DESC_BOB
-                + TAG_DESC_BOB;
+                + TAG_DESC_BOB
+                + REMARK_DESC_BOB;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
                 .withName(VALID_NAME_AMY)
@@ -141,7 +145,9 @@ public class EditCommandParserTest {
                 .withEmail(VALID_EMAIL_AMY)
                 .withAddress(VALID_ADDRESS_AMY)
                 .withFamily(VALID_FAMILY_BOB)
-                .withTags(VALID_TAG_BOB).build();
+                .withTags(VALID_TAG_BOB)
+                .withRemark(VALID_REMARK_BOB)
+                .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -207,6 +213,8 @@ public class EditCommandParserTest {
         // remark
         userInput = targetIndex.getOneBased() + REMARK_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withRemark(VALID_REMARK_AMY).build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
 
         // 2 tags
         userInput = targetIndex.getOneBased() + TAG_DESC_BOB + TAG_DESC_AMY;
@@ -250,11 +258,13 @@ public class EditCommandParserTest {
                         + PHONE_DESC_BOB
                         + ADDRESS_DESC_BOB
                         + EMAIL_DESC_BOB
+                        + REMARK_DESC_AMY
+                        + REMARK_DESC_BOB
                         + CommandTestUtil.TAG_DESC_BOB;
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                                                             PREFIX_INCOME, PREFIX_FAMILY));
+                                                             PREFIX_INCOME, PREFIX_FAMILY, PREFIX_REMARK));
 
         // multiple invalid values
         userInput = targetIndex.getOneBased()

--- a/src/test/java/seedu/realodex/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/ParserUtilTest.java
@@ -20,6 +20,7 @@ import seedu.realodex.model.person.Family;
 import seedu.realodex.model.person.Income;
 import seedu.realodex.model.person.Name;
 import seedu.realodex.model.person.Phone;
+import seedu.realodex.model.remark.Remark;
 import seedu.realodex.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -40,6 +41,9 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "buyer";
     private static final String VALID_TAG_2 = "seller";
+
+    private static final String VALID_REMARK_ONE = "I am Denzel Washington";
+    private static final String VALID_REMARK_TWO = "I am Al Pacino";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -268,5 +272,22 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(tagSetWithMultipleDuplicates, expectedTagSet);
+    }
+
+    @Test
+    public void parseRemark_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseRemark((String) null));
+    }
+    @Test
+    public void parseRemark_validValueWithoutWhitespace_returnsRemark() throws Exception {
+        Remark expectedRemark = new Remark(VALID_REMARK_ONE);
+        assertEquals(expectedRemark, ParserUtil.parseRemark(VALID_REMARK_ONE));
+    }
+
+    @Test
+    public void parseRemark_validValueWithWhitespace_returnsTrimmedRemark() throws Exception {
+        String remarkWithWhitespace = WHITESPACE + VALID_REMARK_ONE + WHITESPACE;
+        Remark expectedRemark = new Remark(VALID_REMARK_ONE);
+        assertEquals(expectedRemark, ParserUtil.parseRemark(remarkWithWhitespace));
     }
 }

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -19,6 +19,7 @@ import seedu.realodex.logic.commands.FilterCommand;
 import seedu.realodex.logic.commands.HelpCommand;
 import seedu.realodex.logic.commands.ListCommand;
 import seedu.realodex.logic.parser.exceptions.ParseException;
+import seedu.realodex.model.person.Name;
 import seedu.realodex.model.person.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.Person;
 import seedu.realodex.testutil.EditPersonDescriptorBuilder;
@@ -43,10 +44,21 @@ public class RealodexParserTest {
     }
 
     @Test
-    public void parseCommand_delete() throws Exception {
+    public void parseCommand_deleteByIndex() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_deleteByName() throws Exception {
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + "n/James");
+        assertEquals(new DeleteCommand(new Name("James")), command);
+
+        command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + "n/ Denzel Untrimmed ");
+        assertEquals(new DeleteCommand(new Name("Denzel Untrimmed")), command);
     }
 
     @Test

--- a/src/test/java/seedu/realodex/model/person/NameTest.java
+++ b/src/test/java/seedu/realodex/model/person/NameTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.realodex.testutil.Assert.assertThrows;
 
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 
 public class NameTest {
@@ -18,6 +20,7 @@ public class NameTest {
         String invalidName = "";
         assertThrows(IllegalArgumentException.class, () -> new Name(invalidName));
     }
+
 
     @Test
     public void isValidName() {

--- a/src/test/java/seedu/realodex/model/person/NameTest.java
+++ b/src/test/java/seedu/realodex/model/person/NameTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.realodex.testutil.Assert.assertThrows;
 
-import java.util.ArrayList;
-
 import org.junit.jupiter.api.Test;
 
 public class NameTest {

--- a/src/test/java/seedu/realodex/model/person/PersonTest.java
+++ b/src/test/java/seedu/realodex/model/person/PersonTest.java
@@ -9,6 +9,7 @@ import static seedu.realodex.logic.commands.CommandTestUtil.VALID_FAMILY_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_INCOME_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_AMY;
 import static seedu.realodex.testutil.Assert.assertThrows;
 import static seedu.realodex.testutil.TypicalPersons.ALICE;
@@ -41,7 +42,9 @@ public class PersonTest {
                 .withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB)
                 .withFamily(VALID_FAMILY_BOB)
-                .withTags(VALID_TAG_AMY).build();
+                .withTags(VALID_TAG_AMY)
+                .withRemark(VALID_REMARK_AMY)
+                .build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false

--- a/src/test/java/seedu/realodex/model/person/PersonTest.java
+++ b/src/test/java/seedu/realodex/model/person/PersonTest.java
@@ -10,6 +10,7 @@ import static seedu.realodex.logic.commands.CommandTestUtil.VALID_INCOME_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_AMY;
 import static seedu.realodex.testutil.Assert.assertThrows;
 import static seedu.realodex.testutil.TypicalPersons.ALICE;
@@ -105,6 +106,10 @@ public class PersonTest {
 
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags("buyer").withTags("seller").build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different remarks -> returns false
+        editedAlice = new PersonBuilder(ALICE).withRemark(VALID_REMARK_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/realodex/model/person/RemarkTest.java
+++ b/src/test/java/seedu/realodex/model/person/RemarkTest.java
@@ -1,0 +1,55 @@
+package seedu.realodex.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.realodex.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.realodex.model.remark.Remark;
+
+public class RemarkTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Remark(null));
+    }
+
+    //May seem redundant, but for further iterations where we may validate remarks.
+    @Test
+    public void isValidRemark() {
+        // null name
+        assertThrows(NullPointerException.class, () -> Remark.isValidRemark(null));
+
+        // invalid name
+        // to-do in the future, ideas include but not limited to length constraints, no illegal characters.
+
+        // valid name
+        assertTrue(Remark.isValidRemark("I love apples")); // alphabets only
+        assertTrue(Remark.isValidRemark("12345")); // numbers only
+        assertTrue(Remark.isValidRemark("James Lau the 1st")); // alphanumeric characters
+        assertTrue(Remark.isValidRemark("New York")); // with capital letters
+        assertTrue(Remark.isValidRemark("Tony Stark, genius playboy billionaire philanthropist")); // long remark
+    }
+
+    @Test
+    public void equals() {
+        Remark remark = new Remark("Valid Remark");
+
+        // same values -> returns true
+        assertTrue(remark.equals(new Remark("Valid Remark")));
+
+        // same object -> returns true
+        assertTrue(remark.equals(remark));
+
+        // null -> returns false
+        assertFalse(remark == null);
+
+        // different types -> returns false
+        assertFalse(remark.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(remark.equals(new Remark("Other Valid Name")));
+    }
+}
+

--- a/src/test/java/seedu/realodex/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/realodex/testutil/TypicalPersons.java
@@ -4,10 +4,15 @@ import static seedu.realodex.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_FAMILY_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_FAMILY_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_INCOME_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_INCOME_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_BOB;
 
@@ -71,17 +76,17 @@ public class TypicalPersons {
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY)
             .withPhone(VALID_PHONE_AMY)
-            .withIncome("20000")
+            .withIncome(VALID_INCOME_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-            .withFamily("4")
+            .withFamily(VALID_FAMILY_AMY)
             .withTags(VALID_TAG_AMY).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB)
             .withPhone(VALID_PHONE_BOB)
-            .withIncome("30000")
+            .withIncome(VALID_INCOME_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-            .withFamily("4")
+            .withFamily(VALID_FAMILY_BOB)
             .withTags(VALID_TAG_BOB)
-            .withRemark("Testing remark")
+            .withRemark(VALID_REMARK_BOB)
             .build();
 
     public static final String KEYPHRASE_MATCHING_MEIER = "Meier"; // A keyphrase that matches MEIER


### PR DESCRIPTION
## Description:
This pull request enhances the test coverage for the Realodex application by adding new tests and remarks related to the delete functionality. The changes aim to improve the robustness and reliability of the codebase by covering edge cases and potential future expansions.

## Changes Made:
-Added remark tests for future expansion.

-Implemented different remarks tests in EditPersonDescriptorTest and PersonTest.

-Added remarks to test subjects in CommandTestUtil.

-Included an optional remark test in AddCommandParserTest.

-Added some tests for DeleteCommandParser.

-Implemented a test for throwing a ParseException for invalid names in DeleteCommandParser.

-Added a small remark test to EditCommandParserTest.

-Included remark tests in ParserUtilTest.

-Added a delete by name parser test to RealodexParserTest.

## Purpose:
These changes aim to enhance the test suite for the Realodex application, ensuring better coverage and reliability of the codebase. By adding tests for delete functionality and including remarks for potential future expansions, we improve the overall quality of the software.