### PR TITLE
Modify clear command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -129,6 +129,12 @@ Lists all clients in Realodex.
 
 Format: `list`
 
+### Clearing Realodex : `clearRealodex`
+
+Clears all clients in Realodex.
+
+Format: `clearRealodex`
+
 ### Help : `help`
 
 Generates a pop-up window which is a summarised version of the User Guide.
@@ -183,8 +189,9 @@ Action     | Format, Examples
 **Add**    | `add n/NAME p/PHONE i/INCOME e/EMAIL a/ADDRESS f/FAMILY t/TAG [r/REMARK]` <br> e.g. `add n/John Doe p/98765432 i/20000 e/johnd@example.com a/311, Clementi Ave 2, #02-25 f/4 r/Buyer t/Owes $1000.`
 **Delete (by name)** | `delete n/NAME`<br> e.g. `delete n/John`
 **Delete (by index)** | `delete INDEX`<br> e.g. `delete 3`
-**edit** | `edit INDEX [n/NAME] [p/PHONE] [i/INCOME] [e/EMAIL] [a/ADDRESS] [f/FAMILY] [t/TAG] [r/REMARK]` <br> e.g. `edit 2 n/Denzel i/100000`
-**filter** | `filter STRING`<br> e.g. `filter David`
-**list**   | `list`
-**help** | `help`
-**exit**   | `exit`
+**Edit** | `edit INDEX [n/NAME] [p/PHONE] [i/INCOME] [e/EMAIL] [a/ADDRESS] [f/FAMILY] [t/TAG] [r/REMARK]` <br> e.g. `edit 2 n/Denzel i/100000`
+**Filter** | `filter STRING`<br> e.g. `filter David`
+**List**   | `list`
+**Clear**| `clearRealodex`
+**Help** | `help`
+**Exit**   | `exit`

--- a/src/main/java/seedu/realodex/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/ClearCommand.java
@@ -10,10 +10,10 @@ import seedu.realodex.model.Realodex;
  */
 public class ClearCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear";
+    public static final String COMMAND_WORD = "clearRealodex";
     public static final String MESSAGE_SUCCESS = "Realodex has been cleared!";
     public static final String MESSAGE_CLEAR_HELP = "Clear Command: Clears all entries in Realodex.\n"
-            + "Format: clear\n";
+            + "Format: clearRealodex\n";
 
 
     @Override


### PR DESCRIPTION
# Modify Clear Command
This pull request introduces changes to the `clear` command to further differentiate it from the `delete` command to reduce the chances of users using `clear` instead of `delete` with catastrophic conseuqneces. The changes made are:

- `clearRealodex` is now the command to clear the entire Realodex instead of just `clear`
   - Modified the string input to read `clearRealodex` before triggering the command.
- Update the UG to reflect the changes.

***

## Fixes issue #144