### PR TITLE
Standardise List View After Delete Command

### DIFF
--- a/src/main/java/seedu/realodex/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/DeleteCommand.java
@@ -66,6 +66,7 @@ public class DeleteCommand extends Command {
         }
 
         model.deletePerson(personToDelete);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 


### PR DESCRIPTION
Fix #147 

# Proposed Change
This PR introduces changes to the delete command logic. After a successful delete operation on a filtered list, the application will now revert to displaying the original, unfiltered list. This change aims to align the delete command's behavior with that of other commands, ensuring consistency across the application.

# Rationale
Aligning the delete command behavior with other commands enhances the predictability of the application's UI. It ensures that users experience a consistent and intuitive interface, which is crucial for usability and overall user satisfaction.

# Impact
This change is expected to improve the user experience by eliminating confusion and making the application's behavior more intuitive. It aligns with established UI patterns and contributes to a more cohesive interaction design.