### PR TITLE
V1.3 help individualised help

### DIFF
--- a/src/main/java/seedu/realodex/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/ClearCommand.java
@@ -10,10 +10,10 @@ import seedu.realodex.model.Realodex;
  */
 public class ClearCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear";
+    public static final String COMMAND_WORD = "clearRealodex";
     public static final String MESSAGE_SUCCESS = "Realodex has been cleared!";
     public static final String MESSAGE_CLEAR_HELP = "Clear Command: Clears all entries in Realodex.\n"
-            + "Format: clear\n";
+            + "Format: clearRealodex\n";
 
 
     @Override

--- a/src/main/java/seedu/realodex/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/FilterCommand.java
@@ -20,7 +20,7 @@ public class FilterCommand extends Command {
             + "Parameters: KEYPHRASE (Non-empty String)\n"
             + "Example: " + COMMAND_WORD + " alice tan";
 
-    public static final String MESSAGE_FIND_HELP = "Filter Command: Filters clients whose names contain "
+    public static final String MESSAGE_FILTER_HELP = "Filter Command: Filters clients whose names contain "
             + "the specified keyphrase (case-insensitive) and displays them as a list with index numbers.\n"
             + "Format: filter KEYPHRASE\n"
             + "Example: filter Jus\n";

--- a/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
@@ -23,7 +23,7 @@ public class HelpCommand extends Command {
     private final String command;
 
     public HelpCommand(String command) {
-        this.command = command;
+        this.command = command.trim();
     }
 
     @Override
@@ -52,5 +52,20 @@ public class HelpCommand extends Command {
         default:
             return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
         }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof HelpCommand)) {
+            return false;
+        }
+
+        HelpCommand otherHelpCommand = (HelpCommand) other;
+        return command.equals(otherHelpCommand.command);
     }
 }

--- a/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
@@ -1,26 +1,18 @@
 package seedu.realodex.logic.commands;
 
-import seedu.realodex.model.Model;
-
 import static seedu.realodex.logic.commands.AddCommand.MESSAGE_ADD_HELP;
 import static seedu.realodex.logic.commands.ClearCommand.MESSAGE_CLEAR_HELP;
 import static seedu.realodex.logic.commands.DeleteCommand.MESSAGE_DELETE_HELP;
 import static seedu.realodex.logic.commands.EditCommand.MESSAGE_EDIT_HELP;
-import static seedu.realodex.logic.commands.ExitCommand.MESSAGE_EXIT_HELP;
 import static seedu.realodex.logic.commands.FilterCommand.MESSAGE_FILTER_HELP;
 import static seedu.realodex.logic.commands.ListCommand.MESSAGE_LIST_HELP;
+
+import seedu.realodex.model.Model;
 
 /**
  * Format full help instructions for every command for display.
  */
 public class HelpCommand extends Command {
-
-    private final String command;
-
-    public HelpCommand(String command) {
-        this.command = command;
-    }
-
     public static final String COMMAND_WORD = "help";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
@@ -28,27 +20,33 @@ public class HelpCommand extends Command {
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
+    private final String command;
+
+    public HelpCommand(String command) {
+        this.command = command;
+    }
+
     @Override
     public CommandResult execute(Model model) {
 
         switch (command) {
 
-        case "add" :
+        case "add":
             return new CommandResult(MESSAGE_ADD_HELP, false, false);
 
-        case "clear" :
+        case "clear":
             return new CommandResult(MESSAGE_CLEAR_HELP, false, false);
 
-        case "delete" :
+        case "delete":
             return new CommandResult(MESSAGE_DELETE_HELP, false, false);
 
-        case "edit" :
+        case "edit":
             return new CommandResult(MESSAGE_EDIT_HELP, false, false);
 
-        case "filter" :
+        case "filter":
             return new CommandResult(MESSAGE_FILTER_HELP, false, false);
 
-        case "list" :
+        case "list":
             return new CommandResult(MESSAGE_LIST_HELP, false, false);
 
         default:

--- a/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
@@ -2,10 +2,24 @@ package seedu.realodex.logic.commands;
 
 import seedu.realodex.model.Model;
 
+import static seedu.realodex.logic.commands.AddCommand.MESSAGE_ADD_HELP;
+import static seedu.realodex.logic.commands.ClearCommand.MESSAGE_CLEAR_HELP;
+import static seedu.realodex.logic.commands.DeleteCommand.MESSAGE_DELETE_HELP;
+import static seedu.realodex.logic.commands.EditCommand.MESSAGE_EDIT_HELP;
+import static seedu.realodex.logic.commands.ExitCommand.MESSAGE_EXIT_HELP;
+import static seedu.realodex.logic.commands.FilterCommand.MESSAGE_FILTER_HELP;
+import static seedu.realodex.logic.commands.ListCommand.MESSAGE_LIST_HELP;
+
 /**
  * Format full help instructions for every command for display.
  */
 public class HelpCommand extends Command {
+
+    private final String command;
+
+    public HelpCommand(String command) {
+        this.command = command;
+    }
 
     public static final String COMMAND_WORD = "help";
 
@@ -16,6 +30,29 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+
+        switch (command) {
+
+        case "add" :
+            return new CommandResult(MESSAGE_ADD_HELP, false, false);
+
+        case "clear" :
+            return new CommandResult(MESSAGE_CLEAR_HELP, false, false);
+
+        case "delete" :
+            return new CommandResult(MESSAGE_DELETE_HELP, false, false);
+
+        case "edit" :
+            return new CommandResult(MESSAGE_EDIT_HELP, false, false);
+
+        case "filter" :
+            return new CommandResult(MESSAGE_FILTER_HELP, false, false);
+
+        case "list" :
+            return new CommandResult(MESSAGE_LIST_HELP, false, false);
+
+        default:
+            return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        }
     }
 }

--- a/src/main/java/seedu/realodex/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/HelpCommandParser.java
@@ -1,0 +1,23 @@
+package seedu.realodex.logic.parser;
+
+import seedu.realodex.logic.commands.HelpCommand;
+import seedu.realodex.logic.parser.exceptions.ParseException;
+
+import static seedu.realodex.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class HelpCommandParser implements Parser<HelpCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public HelpCommand parse(String command) throws ParseException {
+        command = command.trim();
+        return new HelpCommand(command);
+    }
+}

--- a/src/main/java/seedu/realodex/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/HelpCommandParser.java
@@ -3,8 +3,6 @@ package seedu.realodex.logic.parser;
 import seedu.realodex.logic.commands.HelpCommand;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 
-import static seedu.realodex.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */

--- a/src/main/java/seedu/realodex/logic/parser/RealodexParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/RealodexParser.java
@@ -46,36 +46,68 @@ public class RealodexParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
+        //just for checking if help is called so that trimming is possible
+        String nonFinalArguments = matcher.group("arguments");
+
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)
         // log messages such as the one below.
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
+        boolean isHelp = false;
+        if (nonFinalArguments.trim().equalsIgnoreCase("help")) {
+            isHelp = true;
+        }
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
             return new AddCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
             return new ClearCommand();
 
         case FilterCommand.COMMAND_WORD:
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
             return new FilterCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
             return new ListCommand();
 
         case ExitCommand.COMMAND_WORD:
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            if (isHelp) {
+                return new HelpCommandParser().parse(commandWord);
+            }
+            return new HelpCommand("");
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/realodex/logic/parser/RealodexParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/RealodexParser.java
@@ -98,15 +98,9 @@ public class RealodexParser {
             return new ListCommand();
 
         case ExitCommand.COMMAND_WORD:
-            if (isHelp) {
-                return new HelpCommandParser().parse(commandWord);
-            }
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            if (isHelp) {
-                return new HelpCommandParser().parse(commandWord);
-            }
             return new HelpCommand("");
 
         default:

--- a/src/main/java/seedu/realodex/ui/HelpWindow.java
+++ b/src/main/java/seedu/realodex/ui/HelpWindow.java
@@ -5,7 +5,7 @@ import static seedu.realodex.logic.commands.ClearCommand.MESSAGE_CLEAR_HELP;
 import static seedu.realodex.logic.commands.DeleteCommand.MESSAGE_DELETE_HELP;
 import static seedu.realodex.logic.commands.EditCommand.MESSAGE_EDIT_HELP;
 import static seedu.realodex.logic.commands.ExitCommand.MESSAGE_EXIT_HELP;
-import static seedu.realodex.logic.commands.FilterCommand.MESSAGE_FIND_HELP;
+import static seedu.realodex.logic.commands.FilterCommand.MESSAGE_FILTER_HELP;
 import static seedu.realodex.logic.commands.ListCommand.MESSAGE_LIST_HELP;
 
 import java.util.logging.Logger;
@@ -48,7 +48,7 @@ public class HelpWindow extends UiPart<Stage> {
                 + MESSAGE_CLEAR_HELP + "\n"
                 + MESSAGE_EDIT_HELP + "\n"
                 + MESSAGE_LIST_HELP + "\n"
-                + MESSAGE_FIND_HELP + "\n"
+                + MESSAGE_FILTER_HELP + "\n"
                 + MESSAGE_EXIT_HELP + "\n"
                 + HELP_MESSAGE);
     }

--- a/src/test/java/seedu/realodex/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/realodex/logic/commands/HelpCommandTest.java
@@ -15,6 +15,6 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/realodex/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/realodex/logic/commands/HelpCommandTest.java
@@ -1,20 +1,56 @@
 package seedu.realodex.logic.commands;
 
+import static seedu.realodex.logic.commands.AddCommand.MESSAGE_ADD_HELP;
+import static seedu.realodex.logic.commands.ClearCommand.MESSAGE_CLEAR_HELP;
 import static seedu.realodex.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.realodex.logic.commands.DeleteCommand.MESSAGE_DELETE_HELP;
+import static seedu.realodex.logic.commands.EditCommand.MESSAGE_EDIT_HELP;
+import static seedu.realodex.logic.commands.FilterCommand.MESSAGE_FILTER_HELP;
 import static seedu.realodex.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
+import static seedu.realodex.logic.commands.ListCommand.MESSAGE_LIST_HELP;
+import static seedu.realodex.testutil.TypicalPersons.getTypicalRealodex;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.realodex.model.Model;
 import seedu.realodex.model.ModelManager;
+import seedu.realodex.model.UserPrefs;
 
 public class HelpCommandTest {
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private Model model = new ModelManager(getTypicalRealodex(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalRealodex(), new UserPrefs());
 
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
         assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_commandhelp_success() {
+        CommandResult expectedAddHelpCommandResult = new CommandResult(MESSAGE_ADD_HELP,
+                false, false);
+        assertCommandSuccess(new HelpCommand("add"), model, expectedAddHelpCommandResult, expectedModel);
+
+        CommandResult expectedClearHelpCommandResult = new CommandResult(MESSAGE_CLEAR_HELP,
+                false, false);
+        assertCommandSuccess(new HelpCommand("clear"), model, expectedClearHelpCommandResult, expectedModel);
+
+        CommandResult expectedDeleteHelpCommandResult = new CommandResult(MESSAGE_DELETE_HELP,
+                false, false);
+        assertCommandSuccess(new HelpCommand("delete"), model, expectedDeleteHelpCommandResult, expectedModel);
+
+        CommandResult expectedEditHelpCommandResult = new CommandResult(MESSAGE_EDIT_HELP,
+                false, false);
+        assertCommandSuccess(new HelpCommand("edit"), model, expectedEditHelpCommandResult, expectedModel);
+
+        CommandResult expectedFilterHelpCommandResult = new CommandResult(MESSAGE_FILTER_HELP,
+                false, false);
+        assertCommandSuccess(new HelpCommand("filter"), model, expectedFilterHelpCommandResult, expectedModel);
+
+        CommandResult expectedListHelpCommandResult = new CommandResult(MESSAGE_LIST_HELP,
+                false, false);
+        assertCommandSuccess(new HelpCommand("list"), model, expectedListHelpCommandResult, expectedModel);
+
     }
 }

--- a/src/test/java/seedu/realodex/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/HelpCommandParserTest.java
@@ -1,0 +1,46 @@
+package seedu.realodex.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.realodex.logic.commands.Command;
+import seedu.realodex.logic.commands.FilterCommand;
+import seedu.realodex.logic.commands.HelpCommand;
+import seedu.realodex.logic.parser.exceptions.ParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+public class HelpCommandParserTest {
+    private HelpCommandParser parser = new HelpCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsFilterCommand() throws ParseException {
+        HelpCommand expectedHelpCommand = new HelpCommand("");
+        assertParseSuccess(parser, "", expectedHelpCommand);
+
+        //test for spaces in input
+        HelpCommand expectedSpaceHelpCommand = new HelpCommand("");
+        assertParseSuccess(parser, "   ", expectedSpaceHelpCommand);
+
+        HelpCommand expectedAddHelpCommand = new HelpCommand("add");
+        assertParseSuccess(parser, "add", expectedAddHelpCommand);
+
+        HelpCommand expectedClearHelpCommand = new HelpCommand("clear");
+        assertParseSuccess(parser, "clear", expectedClearHelpCommand);
+
+        HelpCommand expectedDeleteHelpCommand = new HelpCommand("delete");
+        assertParseSuccess(parser, "delete", expectedDeleteHelpCommand);
+
+        HelpCommand expectedEditHelpCommand = new HelpCommand("edit");
+        assertParseSuccess(parser, "edit", expectedEditHelpCommand);
+
+        HelpCommand expectedFilterHelpCommand = new HelpCommand("filter");
+        assertParseSuccess(parser, "filter", expectedFilterHelpCommand);
+
+        HelpCommand expectedListHelpCommand = new HelpCommand("list");
+        assertParseSuccess(parser, "list", expectedListHelpCommand);
+
+
+
+
+    }
+}

--- a/src/test/java/seedu/realodex/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/HelpCommandParserTest.java
@@ -1,13 +1,11 @@
 package seedu.realodex.logic.parser;
 
+import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
 import org.junit.jupiter.api.Test;
-import seedu.realodex.logic.commands.Command;
-import seedu.realodex.logic.commands.FilterCommand;
+
 import seedu.realodex.logic.commands.HelpCommand;
 import seedu.realodex.logic.parser.exceptions.ParseException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 public class HelpCommandParserTest {
     private HelpCommandParser parser = new HelpCommandParser();

--- a/src/test/java/seedu/realodex/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/HelpCommandParserTest.java
@@ -11,7 +11,7 @@ public class HelpCommandParserTest {
     private HelpCommandParser parser = new HelpCommandParser();
 
     @Test
-    public void parse_validArgs_returnsFilterCommand() throws ParseException {
+    public void parse_validArgs_returnsHelpCommand() throws ParseException {
         HelpCommand expectedHelpCommand = new HelpCommand("");
         assertParseSuccess(parser, "", expectedHelpCommand);
 
@@ -36,9 +36,5 @@ public class HelpCommandParserTest {
 
         HelpCommand expectedListHelpCommand = new HelpCommand("list");
         assertParseSuccess(parser, "list", expectedListHelpCommand);
-
-
-
-
     }
 }

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -99,9 +99,9 @@ public class RealodexParserTest {
 
     @Test
     public void parseCommand_clear_help() throws Exception {
-        assertTrue(parser.parseCommand("clear help") instanceof HelpCommand);
-        HelpCommand expected = new HelpCommand("clear");
-        assertEquals(parser.parseCommand("clear help"), expected);
+        assertTrue(parser.parseCommand("clearRealodex help") instanceof HelpCommand);
+        HelpCommand expected = new HelpCommand("clearRealodex");
+        assertEquals(parser.parseCommand("clearRealodex help"), expected);
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -91,6 +91,48 @@ public class RealodexParserTest {
     }
 
     @Test
+    public void parseCommand_add_help() throws Exception {
+        assertTrue(parser.parseCommand("add help") instanceof HelpCommand);
+        HelpCommand expected = new HelpCommand("add");
+        assertEquals(parser.parseCommand("add help"), expected);
+    }
+
+    @Test
+    public void parseCommand_clear_help() throws Exception {
+        assertTrue(parser.parseCommand("clear help") instanceof HelpCommand);
+        HelpCommand expected = new HelpCommand("clear");
+        assertEquals(parser.parseCommand("clear help"), expected);
+    }
+
+    @Test
+    public void parseCommand_delete_help() throws Exception {
+        assertTrue(parser.parseCommand("delete help") instanceof HelpCommand);
+        HelpCommand expected = new HelpCommand("delete");
+        assertEquals(parser.parseCommand("delete help"), expected);
+    }
+
+    @Test
+    public void parseCommand_edit_help() throws Exception {
+        assertTrue(parser.parseCommand("edit help") instanceof HelpCommand);
+        HelpCommand expected = new HelpCommand("edit");
+        assertEquals(parser.parseCommand("edit help"), expected);
+    }
+
+    @Test
+    public void parseCommand_filter_help() throws Exception {
+        assertTrue(parser.parseCommand("filter help") instanceof HelpCommand);
+        HelpCommand expected = new HelpCommand("filter");
+        assertEquals(parser.parseCommand("filter help"), expected);
+    }
+
+    @Test
+    public void parseCommand_list_help() throws Exception {
+        assertTrue(parser.parseCommand("list help") instanceof HelpCommand);
+        HelpCommand expected = new HelpCommand("list");
+        assertEquals(parser.parseCommand("list help"), expected);
+    }
+
+    @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);


### PR DESCRIPTION
# Enhance Help
This pull request introduces enhancements to the `help` command, where help for a specified command can be requested.

- Parsing for commands in RealodexParser now have an extra check to check if help is being requested for that command, or just an execution of that command.
    - Add tests for RealodexParser to test the cases where help is requested for each command.
- New HelpCommandParser class created that parses the variation of help commands (help, add help, delete help etc).
    - Add corresponding tests to test for the successful parsing of various commands.
- Add equals method for HelpCommand as it now has a string field.
    - Add corresponding tests to test that the method behaves as expected.

- Help messages may change in future iterations of this PR.


***

## Fixes Issue #158