### PR TITLE
Refactor `Prefix` back to one constructor field, fix `Birthday` to prevent `NoElementException`

### DIFF
--- a/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
@@ -99,7 +99,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         ParserUtilResult<Birthday> birthdayStored = ParserUtil
                 .parseBirthdayReturnStored(argMultimap
-                                                   .getValue(PREFIX_BIRTHDAY)
+                                                   .getValueOrDefault(PREFIX_BIRTHDAY)
                                                    .orElseThrow());
 
 

--- a/src/main/java/seedu/realodex/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/realodex/logic/parser/ArgumentMultimap.java
@@ -70,7 +70,7 @@ public class ArgumentMultimap {
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {
-        return getValue(new Prefix("", "")).orElse("");
+        return getValue(new Prefix("")).orElse("");
     }
 
     /**

--- a/src/main/java/seedu/realodex/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/realodex/logic/parser/ArgumentTokenizer.java
@@ -99,11 +99,11 @@ public class ArgumentTokenizer {
         prefixPositions.sort((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition());
 
         // Insert a PrefixPosition to represent the preamble
-        PrefixPosition preambleMarker = new PrefixPosition(new Prefix("", ""), 0);
+        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
         prefixPositions.add(0, preambleMarker);
 
         // Add a dummy PrefixPosition to represent the end of the string
-        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix("", ""), argsString.length());
+        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix(""), argsString.length());
         prefixPositions.add(endPositionMarker);
 
         // Map prefixes to their argument values (if any)

--- a/src/main/java/seedu/realodex/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/realodex/logic/parser/CliSyntax.java
@@ -6,24 +6,24 @@ package seedu.realodex.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/", "name");
-    public static final Prefix PREFIX_NAME_CAPS = new Prefix("N/", "name");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/", "phone");
-    public static final Prefix PREFIX_PHONE_CAPS = new Prefix("P/", "phone");
-    public static final Prefix PREFIX_INCOME = new Prefix("i/", "income");
-    public static final Prefix PREFIX_INCOME_CAPS = new Prefix("I/", "income");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/", "address");
-    public static final Prefix PREFIX_ADDRESS_CAPS = new Prefix("A/", "address");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/", "email");
-    public static final Prefix PREFIX_EMAIL_CAPS = new Prefix("E/", "email");
-    public static final Prefix PREFIX_FAMILY = new Prefix("f/", "family");
-    public static final Prefix PREFIX_FAMILY_CAPS = new Prefix("F/", "family");
+    public static final Prefix PREFIX_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_NAME_CAPS = new Prefix("N/");
+    public static final Prefix PREFIX_PHONE = new Prefix("p/");
+    public static final Prefix PREFIX_PHONE_CAPS = new Prefix("P/");
+    public static final Prefix PREFIX_INCOME = new Prefix("i/");
+    public static final Prefix PREFIX_INCOME_CAPS = new Prefix("I/");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_ADDRESS_CAPS = new Prefix("A/");
+    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
+    public static final Prefix PREFIX_EMAIL_CAPS = new Prefix("E/");
+    public static final Prefix PREFIX_FAMILY = new Prefix("f/");
+    public static final Prefix PREFIX_FAMILY_CAPS = new Prefix("F/");
 
-    public static final Prefix PREFIX_TAG = new Prefix("t/", "tag");
-    public static final Prefix PREFIX_TAG_CAPS = new Prefix("T/", "tag");
-    public static final Prefix PREFIX_REMARK = new Prefix("r/", "remark");
-    public static final Prefix PREFIX_REMARK_CAPS = new Prefix("R/", "remark");
-    public static final Prefix PREFIX_BIRTHDAY = new Prefix("b/", "birthday");
-    public static final Prefix PREFIX_BIRTHDAY_CAPS = new Prefix("B/", "birthday");
+    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_TAG_CAPS = new Prefix("T/");
+    public static final Prefix PREFIX_REMARK = new Prefix("r/");
+    public static final Prefix PREFIX_REMARK_CAPS = new Prefix("R/");
+    public static final Prefix PREFIX_BIRTHDAY = new Prefix("b/");
+    public static final Prefix PREFIX_BIRTHDAY_CAPS = new Prefix("B/");
 }
 

--- a/src/main/java/seedu/realodex/logic/parser/Prefix.java
+++ b/src/main/java/seedu/realodex/logic/parser/Prefix.java
@@ -1,5 +1,6 @@
 package seedu.realodex.logic.parser;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -10,18 +11,30 @@ import java.util.stream.Stream;
  * E.g. 't/' in 'add James t/ friend'.
  */
 public class Prefix {
+    private static final HashMap<String, String> prefixDescriptionMap = new HashMap<>();
     private final String prefix;
     private final String prefixDescription;
+    static {
+        // Populate the HashMap with key-value pairs
+        prefixDescriptionMap.put("n/", "NAME");
+        prefixDescriptionMap.put("p/", "PHONE");
+        prefixDescriptionMap.put("i/", "INCOME");
+        prefixDescriptionMap.put("a/", "ADDRESS");
+        prefixDescriptionMap.put("e/", "EMAIL");
+        prefixDescriptionMap.put("f/", "FAMILY");
+        prefixDescriptionMap.put("t/", "TAG");
+        prefixDescriptionMap.put("r/", "REMARK");
+        prefixDescriptionMap.put("b/", "BIRTHDAY");
+    }
 
     /**
      * Constructs a Prefix object with the given prefix and its representation.
      *
      * @param prefix The prefix string.
-     * @param prefixDescription The string representation of the prefix.
      */
-    public Prefix(String prefix, String prefixDescription) {
+    public Prefix(String prefix) {
         this.prefix = prefix;
-        this.prefixDescription = prefixDescription.toUpperCase();
+        this.prefixDescription = prefixDescriptionMap.get(prefix.toLowerCase());
     }
 
     /**

--- a/src/main/java/seedu/realodex/logic/parser/Prefix.java
+++ b/src/main/java/seedu/realodex/logic/parser/Prefix.java
@@ -34,7 +34,7 @@ public class Prefix {
      */
     public Prefix(String prefix) {
         this.prefix = prefix;
-        this.prefixDescription = prefixDescriptionMap.get(prefix.toLowerCase());
+        this.prefixDescription = prefixDescriptionMap.getOrDefault(prefix.toLowerCase(), "");
     }
 
     /**

--- a/src/test/java/seedu/realodex/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/ArgumentTokenizerTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 
 public class ArgumentTokenizerTest {
 
-    private final Prefix unknownPrefix = new Prefix("--u", "--u");
-    private final Prefix pSlash = new Prefix("p/", "phone");
-    private final Prefix dashT = new Prefix("-t", "-t");
-    private final Prefix hatQ = new Prefix("^Q", "^Q");
+    private final Prefix unknownPrefix = new Prefix("--u");
+    private final Prefix pSlash = new Prefix("p/");
+    private final Prefix dashT = new Prefix("-t");
+    private final Prefix hatQ = new Prefix("^Q");
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -138,13 +138,13 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void equalsMethod() {
-        Prefix aaa = new Prefix("aaa", "aaa");
+        Prefix aaa = new Prefix("aaa");
 
         assertEquals(aaa, aaa);
-        assertEquals(aaa, new Prefix("aaa", "aaa"));
+        assertEquals(aaa, new Prefix("aaa"));
 
         assertNotEquals(aaa, "aaa");
-        assertNotEquals(aaa, new Prefix("aab", "aab"));
+        assertNotEquals(aaa, new Prefix("aab"));
     }
 
 }

--- a/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
@@ -55,7 +55,7 @@ class PredicateProducerTest {
     @Test
     void createPredicate_assertionErrorWhenInvalidPrefix() {
         PredicateProducer predicateProducer = new PredicateProducer();
-        Prefix unhandledPrefix = new Prefix("unhandled/", "");
+        Prefix unhandledPrefix = new Prefix("unhandled/");
 
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
 


### PR DESCRIPTION
# PR Description:

In this PR, we propose a refactoring of the Prefix class to enhance its usability and robustness. The refactor involves modifying the Prefix class to accept a single input, leveraging a static HashMap to retrieve prefix descriptions. This change aims to reduce potential errors and enhance defensive programming practices.

## Changes Introduced:

Modification of Prefix Class: The Prefix class has been updated to receive a single input parameter.

Integration of Static HashMap: We have incorporated a static HashMap within the Prefix class to retrieve prefix descriptions. This hashmap enhances the reliability of prefix retrieval and reduces the likelihood of errors.

Enhanced Usability: By refactoring the Prefix class in this manner, we ensure improved usability and ease of integration within our codebase.

## Overall, this refactor contributes to the overall maintainability and robustness of our codebase, aligning with best practices in software development.