### PR TITLE
V1.3 Filter by Tags

### DIFF
--- a/src/main/java/seedu/realodex/logic/Messages.java
+++ b/src/main/java/seedu/realodex/logic/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_NAME = "The client name provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+                "Too many values specified for the following single-valued field(s): ";
     public static final String MESSAGE_MISSING_PREFIXES = "Missing compulsory prefixes in the command! "
             + "Prefixes That Are Missed Are: ";
 

--- a/src/main/java/seedu/realodex/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/FilterCommand.java
@@ -21,7 +21,8 @@ public class FilterCommand extends Command {
 
     public static final String COMMAND_WORD = "filter";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all clients by specified field (name, remark, tag) "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Filters all clients by specified field (name, remark, tag) "
             + "with the specified keyphrase (non-empty, case-insensitive) "
             + "and displays them as a list with index numbers.\n"
             + "Note that although the fields are listed as optional, ONE field must strictly be present.\n"

--- a/src/main/java/seedu/realodex/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/FilterCommand.java
@@ -3,6 +3,7 @@ package seedu.realodex.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.function.Predicate;
 
@@ -20,20 +21,21 @@ public class FilterCommand extends Command {
 
     public static final String COMMAND_WORD = "filter";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all clients by specified field (name, remark) "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all clients by specified field (name, remark, tag) "
             + "with the specified keyphrase (non-empty, case-insensitive) "
             + "and displays them as a list with index numbers.\n"
             + "Note that although the fields are listed as optional, ONE field must strictly be present.\n"
             + "Parameters: "
             + "[" + PREFIX_NAME + "KEYPHRASE] "
-            + "[" + PREFIX_REMARK + "REMARK]\n"
+            + "[" + PREFIX_REMARK + "REMARK]"
+            + "[" + PREFIX_TAG + "TAG]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice tan";
 
     public static final String MESSAGE_FILTER_HELP = "Filter Command: "
-            + "Filters clients by ONE specified field (name, remark)"
+            + "Filters clients by ONE specified field (name, remark, tag)"
             + "with the specified keyphrase (non-empty, case-insensitive) "
             + "and displays them as a list with index numbers.\n"
-            + "Format: filter [n/KEYPHRASE] [r/KEYPHRASE]\n"
+            + "Format: filter [n/KEYPHRASE] [r/KEYPHRASE] [t/TAG]\n"
             + "Example: filter n/Jus\n";
 
     public static final String MESSAGE_FILTER_CONFLICT = "Filter command can only filter by one field.\n";

--- a/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
@@ -3,6 +3,7 @@ package seedu.realodex.logic.parser;
 import static seedu.realodex.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.function.Predicate;
 
@@ -16,7 +17,7 @@ import seedu.realodex.model.person.predicates.PredicateProducer;
  */
 public class FilterCommandParser implements Parser<FilterCommand> {
 
-    private static final Prefix[] POSSIBLE_PREFIXES = { PREFIX_NAME, PREFIX_REMARK };
+    private static final Prefix[] POSSIBLE_PREFIXES = { PREFIX_NAME, PREFIX_REMARK, PREFIX_TAG };
     /**
      * Parses the given {@code String} of arguments in the context of the FilterCommand
      * and returns a FilterCommand object for execution.
@@ -68,7 +69,6 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      * @throws ParseException if the preamble is not empty.
      */
     private void checkEmptyPreamble(PrefixChecker prefixChecker) throws ParseException {
-        // Check for at least one prefix present and no empty preamble
         if (!prefixChecker.checkEmptyPreamble()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
@@ -6,14 +6,12 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.realodex.logic.commands.FilterCommand;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 import seedu.realodex.model.person.Person;
 import seedu.realodex.model.person.predicates.PredicateProducer;
-import seedu.realodex.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FilterCommand object
@@ -49,7 +47,8 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      * @throws ParseException if there's an issue creating the predicate.
      */
 
-    private Predicate<Person> createPredicateForPrefix(Prefix presentPrefix, List<String> keyphrases) throws ParseException {
+    private Predicate<Person> createPredicateForPrefix(Prefix presentPrefix, List<String> keyphrases)
+            throws ParseException {
         checkValidTagsIfApplicable(presentPrefix, keyphrases);
         PredicateProducer predicateProducer = new PredicateProducer();
         return predicateProducer.createPredicate(presentPrefix, keyphrases);

--- a/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
@@ -49,10 +49,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
 
     private Predicate<Person> createPredicateForPrefix(Prefix presentPrefix, List<String> keyphrases)
             throws ParseException {
+        checkValidNameIfApplicable(presentPrefix, keyphrases);
         checkValidTagsIfApplicable(presentPrefix, keyphrases);
         PredicateProducer predicateProducer = new PredicateProducer();
         return predicateProducer.createPredicate(presentPrefix, keyphrases);
     }
+
 
     /**
      * Validates the input arguments using various checks to ensure conformity to syntax requirements.
@@ -110,6 +112,22 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     private void checkNoDuplicatePrefix(PrefixChecker prefixChecker) throws ParseException {
         prefixChecker.checkNoDuplicatePrefix(POSSIBLE_PREFIXES);
+    }
+
+    /**
+     * Validates name keyphrase if the present prefix is for a name. Each keyphrase must conform
+     * to Name constraints.
+     *
+     * @param presentPrefix The prefix to check if it's tag-related.
+     * @param keyphrases The list of keyphrases representing potential tags.
+     * @throws ParseException if any tag keyphrase is invalid.
+     */
+    private void checkValidNameIfApplicable(Prefix presentPrefix, List<String> keyphrases) throws ParseException {
+        if (!presentPrefix.equals(PREFIX_NAME)) {
+            return;
+        }
+        String name = keyphrases.get(keyphrases.size() - 1);
+        ParserUtil.parseName(name);
     }
 
     /**

--- a/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.realodex.logic.commands.FilterCommand;
@@ -33,9 +34,9 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         checkNoDuplicatePrefix(prefixChecker);
 
         Prefix presentPrefix = prefixChecker.findPresentPrefix(POSSIBLE_PREFIXES);
-        String keyphrase = argMultimap.getValue(presentPrefix).get().trim();
+        List<String> keyphrases = argMultimap.getAllValues(presentPrefix);
         PredicateProducer predicateProducer = new PredicateProducer();
-        Predicate<Person> predicate = predicateProducer.createPredicate(presentPrefix, keyphrase);
+        Predicate<Person> predicate = predicateProducer.createPredicate(presentPrefix, keyphrases);
 
         return new FilterCommand(predicate);
     }

--- a/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
@@ -30,7 +30,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
 
         checkEmptyPreamble(prefixChecker);
-        checkOnlyOnePrefixPresent(prefixChecker);
+        checkOnlyOnePrefixTypePresent(prefixChecker);
         checkNoDuplicatePrefix(prefixChecker);
 
         Prefix presentPrefix = prefixChecker.findPresentPrefix(POSSIBLE_PREFIXES);
@@ -49,12 +49,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      * @param prefixChecker the {@link PrefixChecker} used to validate the presence of prefixes.
      * @throws ParseException if no prefixes are present or more than one prefix is found.
      */
-    private void checkOnlyOnePrefixPresent(PrefixChecker prefixChecker) throws ParseException {
+    private void checkOnlyOnePrefixTypePresent(PrefixChecker prefixChecker) throws ParseException {
         // Check for at least one prefix present and no empty preamble
         if (!prefixChecker.anyPrefixesPresent(POSSIBLE_PREFIXES)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
-        if (prefixChecker.moreThanOnePrefixPresent(POSSIBLE_PREFIXES)) {
+        if (prefixChecker.moreThanOnePrefixTypePresent(POSSIBLE_PREFIXES)) {
             throw new ParseException(String.format(
                     MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_FILTER_CONFLICT
             ));

--- a/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/FilterCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.realodex.logic.commands.FilterCommand;
@@ -124,11 +125,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         if (!presentPrefix.equals(PREFIX_TAG)) {
             return;
         }
-        for (String keyphrase : keyphrases) {
-            if (!Tag.isValidTagName(keyphrase)) {
-                throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
-            }
-        }
+        ParserUtil.parseTags(keyphrases);
     }
 
 }

--- a/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
+++ b/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
@@ -34,40 +34,21 @@ public class PrefixChecker {
      * @return {@code true} if any prefix exceeds its allowed occurrence limit, {@code false} otherwise.
      */
     public boolean anyPrefixesPresent(Prefix... prefixes) {
+        assert(prefixes != null);
         return Stream.of(prefixes).anyMatch(this::isPrefixPresent);
     }
 
     /**
-     * Determines if more than one of the provided prefixes are present in the {@code ArgumentMultimap}.
+     * Determines if more than one type of prefixes are present in the {@code ArgumentMultimap}.
      *
      * @param prefixes The prefixes to check.
      * @return {@code true} if more than one prefix is present, {@code false} otherwise.
      */
-    public boolean moreThanOnePrefixPresent(Prefix... prefixes) {
-        return Stream.of(prefixes)
-                .anyMatch(prefix -> isExceedingAllowedOccurrences(prefix));
+    public boolean moreThanOnePrefixTypePresent(Prefix... prefixes) {
+        assert (prefixes != null);
+        return Stream.of(prefixes).filter(this::isPrefixPresent).count() > 1;
     }
 
-
-    /**
-     * Determines whether the occurrence count of a given prefix in the argument multimap exceeds the allowed limit.
-     * Special case prefixes, identified by {@code isSpecialCasePrefix}, are permitted a higher occurrence count than
-     * regular prefixes. This method accounts for such distinctions in its check.
-     *
-     * @param prefix The {@link Prefix} whose occurrences are to be checked.
-     * @return {@code true} if the occurrence count for the prefix exceeds its allowed limit, {@code false} otherwise.
-     */
-    private boolean isExceedingAllowedOccurrences(Prefix prefix) {
-        long count = argumentMultimap.getAllValues(prefix).size();
-
-        if (isSpecialCasePrefix(prefix)) {
-            // Allow up to 2 instances for special case prefixes
-            return count > 2;
-        } else {
-            // Only allow 1 instance for regular prefixes
-            return count > 1;
-        }
-    }
 
     /**
      * Checks if the preamble (text before the first valid prefix) of the {@code ArgumentMultimap} is empty.
@@ -86,6 +67,7 @@ public class PrefixChecker {
      * @throws ParseException If duplicates are found, except for the allowed exceptions.
      */
     public void checkNoDuplicatePrefix(Prefix... prefixes) throws ParseException {
+        assert(prefixes != null);
         Prefix[] duplicatedPrefixes = Stream.of(prefixes)
                 .filter(this::isDuplicatePrefix)
                 .distinct()
@@ -105,6 +87,7 @@ public class PrefixChecker {
      *         {@code false} otherwise.
      */
     private boolean isDuplicatePrefix(Prefix prefix) {
+        assert(prefix != null);
         if (isSpecialCasePrefix(prefix)) {
             return argumentMultimap.containsPrefix(prefix) && argumentMultimap.getAllValues(prefix).size() > 2;
         } else {
@@ -121,6 +104,7 @@ public class PrefixChecker {
      * @return {@code true} if the prefix is a special case, {@code false} otherwise.
      */
     private boolean isSpecialCasePrefix(Prefix prefix) {
+        assert(prefix != null);
         return prefix.equals(PREFIX_TAG);
     }
 
@@ -131,6 +115,7 @@ public class PrefixChecker {
      * @return {@code true} if the prefix is present, {@code false} otherwise.
      */
     public boolean isPrefixPresent(Prefix prefix) {
+        assert(prefix != null);
         return argumentMultimap.containsPrefix(prefix);
     }
 
@@ -142,6 +127,7 @@ public class PrefixChecker {
      * @return The first present prefix, or {@code null} if none are present.
      */
     public Prefix findPresentPrefix(Prefix...prefixes) {
+        assert(prefixes != null);
         for (Prefix prefix : prefixes) {
             if (isPrefixPresent(prefix)) {
                 return prefix;

--- a/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
+++ b/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
@@ -1,11 +1,12 @@
 package seedu.realodex.logic.parser;
 
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
+
 import java.util.stream.Stream;
 
 import seedu.realodex.logic.Messages;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 
-import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * A utility class to check the presence and uniqueness of prefixes in an {@code ArgumentMultimap}.

--- a/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
+++ b/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
@@ -86,7 +86,7 @@ public class PrefixChecker {
      * @return {@code true} if the prefix is considered a duplicate (considering the allowed exceptions),
      *         {@code false} otherwise.
      */
-    private boolean isDuplicatePrefix(Prefix prefix) {
+    public boolean isDuplicatePrefix(Prefix prefix) {
         assert(prefix != null);
         if (isSpecialCasePrefix(prefix)) {
             return argumentMultimap.containsPrefix(prefix) && argumentMultimap.getAllValues(prefix).size() > 2;
@@ -103,7 +103,7 @@ public class PrefixChecker {
      * @param prefix The {@link Prefix} to be checked.
      * @return {@code true} if the prefix is a special case, {@code false} otherwise.
      */
-    private boolean isSpecialCasePrefix(Prefix prefix) {
+    public boolean isSpecialCasePrefix(Prefix prefix) {
         assert(prefix != null);
         return prefix.equals(PREFIX_TAG);
     }

--- a/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
+++ b/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
@@ -5,6 +5,8 @@ import java.util.stream.Stream;
 import seedu.realodex.logic.Messages;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
+
 /**
  * A utility class to check the presence and uniqueness of prefixes in an {@code ArgumentMultimap}.
  * This class provides methods to verify if specific prefixes are provided by the user,
@@ -24,24 +26,47 @@ public class PrefixChecker {
     }
 
     /**
-     * Checks if any of the provided prefixes are present in the {@code ArgumentMultimap}.
+     * Checks if any of the provided prefixes appear more times than allowed in the argument multimap.
+     * This method leverages {@code isExceedingAllowedOccurrences} to determine if the occurrence count
+     * for any given prefix exceeds its permitted limit.
      *
-     * @param prefixes The prefixes to check for presence.
-     * @return {@code true} if any of the prefixes are present, {@code false} otherwise.
+     * @param prefixes An array of {@code Prefix} objects to be checked for excessive occurrences.
+     * @return {@code true} if any prefix exceeds its allowed occurrence limit, {@code false} otherwise.
      */
     public boolean anyPrefixesPresent(Prefix... prefixes) {
         return Stream.of(prefixes).anyMatch(this::isPrefixPresent);
     }
 
     /**
-     * Determines if more than one of the provided prefixes are present in the {@link ArgumentMultimap}.
+     * Determines if more than one of the provided prefixes are present in the {@code ArgumentMultimap}.
      *
      * @param prefixes The prefixes to check.
      * @return {@code true} if more than one prefix is present, {@code false} otherwise.
      */
-
     public boolean moreThanOnePrefixPresent(Prefix... prefixes) {
-        return Stream.of(prefixes).filter(this::isPrefixPresent).count() > 1;
+        return Stream.of(prefixes)
+                .anyMatch(prefix -> isExceedingAllowedOccurrences(prefix));
+    }
+
+
+    /**
+     * Determines whether the occurrence count of a given prefix in the argument multimap exceeds the allowed limit.
+     * Special case prefixes, identified by {@code isSpecialCasePrefix}, are permitted a higher occurrence count than
+     * regular prefixes. This method accounts for such distinctions in its check.
+     *
+     * @param prefix The {@link Prefix} whose occurrences are to be checked.
+     * @return {@code true} if the occurrence count for the prefix exceeds its allowed limit, {@code false} otherwise.
+     */
+    private boolean isExceedingAllowedOccurrences(Prefix prefix) {
+        long count = argumentMultimap.getAllValues(prefix).size();
+
+        if (isSpecialCasePrefix(prefix)) {
+            // Allow up to 2 instances for special case prefixes
+            return count > 2;
+        } else {
+            // Only allow 1 instance for regular prefixes
+            return count > 1;
+        }
     }
 
     /**
@@ -54,21 +79,49 @@ public class PrefixChecker {
     }
 
     /**
-     * Verifies that no duplicate prefixes are present for the provided prefixes.
-     * A duplicate prefix is defined as the same prefix being used multiple times with different values.
+     * Checks for duplicate prefixes in the given array of prefixes, with an exception for tag prefixes
+     * that is allowed to appear at most twice. Throws a {@code ParseException} if duplicates are found.
      *
-     * @param prefixes The prefixes to check for duplicates.
-     * @throws ParseException if duplicate prefixes are found.
+     * @param prefixes An array of {@code Prefix} objects to be checked for duplicates.
+     * @throws ParseException If duplicates are found, except for the allowed exceptions.
      */
-    public void checkNoDuplicatePrefix(Prefix...prefixes) throws ParseException {
-        Prefix[] duplicatedPrefixes = Stream.of(prefixes).distinct()
-                .filter(prefix -> argumentMultimap.containsPrefix(prefix)
-                        && argumentMultimap.getAllValues(prefix).size() > 1)
+    public void checkNoDuplicatePrefix(Prefix... prefixes) throws ParseException {
+        Prefix[] duplicatedPrefixes = Stream.of(prefixes)
+                .filter(this::isDuplicatePrefix)
+                .distinct()
                 .toArray(Prefix[]::new);
 
         if (duplicatedPrefixes.length > 0) {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
+    }
+
+    /**
+     * Determines whether a given prefix is considered a duplicate within the context of an {@code ArgumentMultimap}.
+     * A special case is made for special prefixes where at most 1 duplicate is allowed.
+     *
+     * @param prefix The {@link Prefix} to check for duplication.
+     * @return {@code true} if the prefix is considered a duplicate (considering the allowed exceptions),
+     *         {@code false} otherwise.
+     */
+    private boolean isDuplicatePrefix(Prefix prefix) {
+        if (isSpecialCasePrefix(prefix)) {
+            return argumentMultimap.containsPrefix(prefix) && argumentMultimap.getAllValues(prefix).size() > 2;
+        } else {
+            return argumentMultimap.containsPrefix(prefix) && argumentMultimap.getAllValues(prefix).size() > 1;
+        }
+    }
+
+    /**
+     * Identifies if the given prefix is a special case that is subject to different duplication rules.
+     * For example, tag prefixes are allowed to appear more than once but at most twice
+     * without being considered duplicates.
+     *
+     * @param prefix The {@link Prefix} to be checked.
+     * @return {@code true} if the prefix is a special case, {@code false} otherwise.
+     */
+    private boolean isSpecialCasePrefix(Prefix prefix) {
+        return prefix.equals(PREFIX_TAG);
     }
 
     /**

--- a/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
+++ b/src/main/java/seedu/realodex/logic/parser/PrefixChecker.java
@@ -35,7 +35,6 @@ public class PrefixChecker {
      * @return {@code true} if any prefix exceeds its allowed occurrence limit, {@code false} otherwise.
      */
     public boolean anyPrefixesPresent(Prefix... prefixes) {
-        assert(prefixes != null);
         return Stream.of(prefixes).anyMatch(this::isPrefixPresent);
     }
 
@@ -46,7 +45,6 @@ public class PrefixChecker {
      * @return {@code true} if more than one prefix is present, {@code false} otherwise.
      */
     public boolean moreThanOnePrefixTypePresent(Prefix... prefixes) {
-        assert (prefixes != null);
         return Stream.of(prefixes).filter(this::isPrefixPresent).count() > 1;
     }
 
@@ -68,7 +66,6 @@ public class PrefixChecker {
      * @throws ParseException If duplicates are found, except for the allowed exceptions.
      */
     public void checkNoDuplicatePrefix(Prefix... prefixes) throws ParseException {
-        assert(prefixes != null);
         Prefix[] duplicatedPrefixes = Stream.of(prefixes)
                 .filter(this::isDuplicatePrefix)
                 .distinct()
@@ -87,7 +84,7 @@ public class PrefixChecker {
      * @return {@code true} if the prefix is considered a duplicate (considering the allowed exceptions),
      *         {@code false} otherwise.
      */
-    public boolean isDuplicatePrefix(Prefix prefix) {
+    protected boolean isDuplicatePrefix(Prefix prefix) {
         assert(prefix != null);
         if (isSpecialCasePrefix(prefix)) {
             return argumentMultimap.containsPrefix(prefix) && argumentMultimap.getAllValues(prefix).size() > 2;
@@ -104,7 +101,7 @@ public class PrefixChecker {
      * @param prefix The {@link Prefix} to be checked.
      * @return {@code true} if the prefix is a special case, {@code false} otherwise.
      */
-    public boolean isSpecialCasePrefix(Prefix prefix) {
+    protected boolean isSpecialCasePrefix(Prefix prefix) {
         assert(prefix != null);
         return prefix.equals(PREFIX_TAG);
     }
@@ -115,7 +112,7 @@ public class PrefixChecker {
      * @param prefix The prefix to check for presence.
      * @return {@code true} if the prefix is present, {@code false} otherwise.
      */
-    public boolean isPrefixPresent(Prefix prefix) {
+    protected boolean isPrefixPresent(Prefix prefix) {
         assert(prefix != null);
         return argumentMultimap.containsPrefix(prefix);
     }
@@ -128,7 +125,6 @@ public class PrefixChecker {
      * @return The first present prefix, or {@code null} if none are present.
      */
     public Prefix findPresentPrefix(Prefix...prefixes) {
-        assert(prefixes != null);
         for (Prefix prefix : prefixes) {
             if (isPrefixPresent(prefix)) {
                 return prefix;

--- a/src/main/java/seedu/realodex/model/person/predicates/NameContainsKeyphrasePredicate.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/NameContainsKeyphrasePredicate.java
@@ -6,7 +6,7 @@ import seedu.realodex.commons.util.ToStringBuilder;
 import seedu.realodex.model.person.Person;
 
 /**
- * Tests that a {@code Person}'s {@code Name} contains the keyphrase given.
+ * Tests that a {@code Person}'s {@code Tag} contains the Tag(s) given.
  */
 public class NameContainsKeyphrasePredicate implements Predicate<Person> {
     private final String keyphrase;

--- a/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
@@ -64,7 +64,17 @@ public class PredicateProducer {
 
     }
 
-    //can only put one tag for now
+    /**
+     * Creates a predicate to evaluate if a {@link Person} has specific tag(s).
+     * The predicate checks if the set of tags associated with a person includes the tag(s)
+     * created from the provided string.
+     *
+     * @param string The string from which tag(s) are created. These tag(s) are then used
+     *               in the predicate to check against a person's tags.
+     * @return A {@code Predicate<Person>} that tests whether a person's tags include
+     *         the tag(s) created from the provided string. The predicate returns {@code true}
+     *         if the person's tags contain the specified tag(s), and {@code false} otherwise.
+     */
     public Predicate<Person> createMatchTagsPredicate(String string) {
         Set<Tag> personTags = Set.of(new Tag(string));
         return new TagsMatchPredicate(personTags);

--- a/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
@@ -3,9 +3,11 @@ package seedu.realodex.model.person.predicates;
 import static seedu.realodex.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -13,6 +15,7 @@ import seedu.realodex.logic.commands.FilterCommand;
 import seedu.realodex.logic.parser.Prefix;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 import seedu.realodex.model.person.Person;
+import seedu.realodex.model.tag.Tag;
 
 /**
  * A factory class to produce different types of {@code Predicate<Person>} based on a given prefix and keyphrase.
@@ -37,6 +40,7 @@ public class PredicateProducer {
     private void initialize() {
         predicateMap.put(PREFIX_NAME, NameContainsKeyphrasePredicate::new);
         predicateMap.put(PREFIX_REMARK, RemarkContainsKeyphrasePredicate::new);
+        predicateMap.put(PREFIX_TAG, this::createMatchTagsPredicate);
     }
 
     /**
@@ -58,6 +62,12 @@ public class PredicateProducer {
         assert(predicateCreator != null);
         return predicateCreator.apply(keyphrase.trim());
 
+    }
+
+    //can only put one tag for now
+    public Predicate<Person> createMatchTagsPredicate(String string) {
+        Set<Tag> personTags = Set.of(new Tag(string));
+        return new TagsMatchPredicate(personTags);
     }
 
 }

--- a/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
@@ -80,7 +80,8 @@ public class PredicateProducer {
      */
     public Predicate<Person> createMatchTagsPredicate(List<String> tagStrings) {
         Set<Tag> tagSet = tagStrings.stream().map(Tag::new).collect(Collectors.toSet());
-        return person -> tagSet.stream().allMatch(tag -> person.getTags().contains(tag));
+        return new TagsMatchPredicate(tagSet);
     }
+
 
 }

--- a/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import seedu.realodex.logic.commands.FilterCommand;
 import seedu.realodex.logic.parser.ParserUtil;
@@ -41,8 +40,10 @@ public class PredicateProducer {
      * This method is called during the construction of the {@code PredicateProducer} instance.
      */
     private void initialize() {
-        predicateMap.put(PREFIX_NAME, keyphrases -> new NameContainsKeyphrasePredicate(keyphrases.get(keyphrases.size() - 1)));
-        predicateMap.put(PREFIX_REMARK, keyphrases -> new RemarkContainsKeyphrasePredicate(keyphrases.get(keyphrases.size() - 1)));
+        predicateMap.put(PREFIX_NAME, keyphrases ->
+                new NameContainsKeyphrasePredicate(keyphrases.get(keyphrases.size() - 1)));
+        predicateMap.put(PREFIX_REMARK, keyphrases ->
+                new RemarkContainsKeyphrasePredicate(keyphrases.get(keyphrases.size() - 1)));
         predicateMap.put(PREFIX_TAG, this::createMatchTagsPredicate);
     }
 
@@ -55,7 +56,7 @@ public class PredicateProducer {
      * @param keyphrases The list of keyphrases to be used in the predicate for testing {@code Person} objects.
      *                   For PREFIX_TAG, all keyphrases in the list are considered in creating the predicate.
      * @return A {@code Predicate<Person>} that tests if a {@code Person} object meets the specified criteria.
-     * @throws ParseException if the list of keyphrases is null, empty, contains empty strings, or if the prefix is unhandled.
+     * @throws ParseException if the list of keyphrases is null, empty, contains empty strings, or an unhandled prefix.
      */
     public Predicate<Person> createPredicate(Prefix prefix, List<String> keyphrases) throws ParseException {
         if (keyphrases == null || keyphrases.isEmpty() || keyphrases.stream().anyMatch(String::isEmpty)) {

--- a/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
@@ -46,14 +46,15 @@ public class PredicateProducer {
     }
 
     /**
-     * Creates and returns a {@code Predicate<Person>} based on the provided prefix and keyphrase.
-     * The predicate tests whether a given {@code Person} object meets the criteria
-     * defined by the keyphrase associated with the prefix.
+     * Creates and returns a {@code Predicate<Person>} based on the provided prefix and list of keyphrases.
+     * The predicate tests whether a given {@code Person} object meets the criteria defined by the keyphrases
+     * associated with the prefix. For PREFIX_NAME and PREFIX_REMARK, only one keyphrase should be present.
      *
      * @param prefix The {@code Prefix} that specifies the type of predicate to create.
-     * @param keyphrases The keyphrase to be used in the predicate for testing {@code Person} objects.
-     * @return A {@code Predicate<Person>} that tests if a {@code Person} object meets the criteria.
-     * @throws ParseException if the keyphrase is null or empty, or if the prefix is unhandled.
+     * @param keyphrases The list of keyphrases to be used in the predicate for testing {@code Person} objects.
+     *                   For PREFIX_TAG, all keyphrases in the list are considered in creating the predicate.
+     * @return A {@code Predicate<Person>} that tests if a {@code Person} object meets the specified criteria.
+     * @throws ParseException if the list of keyphrases is null, empty, contains empty strings, or if the prefix is unhandled.
      */
     public Predicate<Person> createPredicate(Prefix prefix, List<String> keyphrases) throws ParseException {
         if (keyphrases == null || keyphrases.isEmpty() || keyphrases.stream().anyMatch(String::isEmpty)) {

--- a/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/PredicateProducer.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import seedu.realodex.logic.commands.FilterCommand;
+import seedu.realodex.logic.parser.ParserUtil;
 import seedu.realodex.logic.parser.Prefix;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 import seedu.realodex.model.person.Person;
@@ -79,8 +80,13 @@ public class PredicateProducer {
      *         if the person's tags contain the specified tag(s), and {@code false} otherwise.
      */
     public Predicate<Person> createMatchTagsPredicate(List<String> tagStrings) {
-        Set<Tag> tagSet = tagStrings.stream().map(Tag::new).collect(Collectors.toSet());
-        return new TagsMatchPredicate(tagSet);
+        try {
+            Set<Tag> tagSet = ParserUtil.parseTags(tagStrings);
+            return new TagsMatchPredicate(tagSet);
+        } catch (ParseException e) {
+            assert false;
+        }
+        return null;
     }
 
 

--- a/src/main/java/seedu/realodex/model/person/predicates/TagsMatchPredicate.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/TagsMatchPredicate.java
@@ -1,0 +1,46 @@
+package seedu.realodex.model.person.predicates;
+
+import seedu.realodex.commons.util.ToStringBuilder;
+import seedu.realodex.model.person.Person;
+import seedu.realodex.model.tag.Tag;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} contains the keyphrase given.
+ */
+public class TagsMatchPredicate implements Predicate<Person> {
+    private final Set<Tag> tagSet;
+
+    public TagsMatchPredicate(Set<Tag> tagSet) {
+        this.tagSet = tagSet;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        Set<Tag> personTags = person.getTags();
+        return personTags.containsAll(tagSet);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TagsMatchPredicate)) {
+            return false;
+        }
+
+        TagsMatchPredicate otherTagsMatchPredicate = (TagsMatchPredicate) other;
+        return tagSet.equals(otherTagsMatchPredicate.tagSet);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("Tag Set", tagSet).toString();
+    }
+
+}

--- a/src/main/java/seedu/realodex/model/person/predicates/TagsMatchPredicate.java
+++ b/src/main/java/seedu/realodex/model/person/predicates/TagsMatchPredicate.java
@@ -1,11 +1,12 @@
 package seedu.realodex.model.person.predicates;
 
+import java.util.Set;
+import java.util.function.Predicate;
+
 import seedu.realodex.commons.util.ToStringBuilder;
 import seedu.realodex.model.person.Person;
 import seedu.realodex.model.tag.Tag;
 
-import java.util.Set;
-import java.util.function.Predicate;
 
 /**
  * Tests that a {@code Person}'s {@code Name} contains the keyphrase given.

--- a/src/test/java/seedu/realodex/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/realodex/logic/commands/FilterCommandTest.java
@@ -5,14 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.realodex.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.realodex.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.realodex.testutil.TypicalPersons.ALICE;
+import static seedu.realodex.testutil.TypicalPersons.BENSON;
 import static seedu.realodex.testutil.TypicalPersons.CARL;
 import static seedu.realodex.testutil.TypicalPersons.DANIEL;
 import static seedu.realodex.testutil.TypicalPersons.ELLE;
+import static seedu.realodex.testutil.TypicalPersons.FIONA;
 import static seedu.realodex.testutil.TypicalPersons.GEORGE;
 import static seedu.realodex.testutil.TypicalPersons.getTypicalRealodex;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +25,8 @@ import seedu.realodex.model.ModelManager;
 import seedu.realodex.model.UserPrefs;
 import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.RemarkContainsKeyphrasePredicate;
+import seedu.realodex.model.person.predicates.TagsMatchPredicate;
+import seedu.realodex.model.tag.Tag;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FilterCommand}.
@@ -110,6 +116,39 @@ public class FilterCommandTest {
         assertEquals(Arrays.asList(CARL, GEORGE), model.getFilteredPersonList());
     }
 
+    @Test
+    public void execute_buyerTag_buyersFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 6);
+        Set<Tag> tagString = Set.of(new Tag("buyer"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(tagString);
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertTrue(model.getFilteredPersonList().containsAll(Arrays.asList(ALICE, BENSON, CARL, DANIEL,
+                                                                            ELLE, GEORGE)));
+    }
+
+    @Test
+    public void execute_sellerTag_buyersFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        Set<Tag> tagString = Set.of(new Tag("seller"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(tagString);
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertTrue(model.getFilteredPersonList().containsAll(Arrays.asList(BENSON, FIONA)));
+    }
+
+    @Test
+    public void execute_bothTags_personsWithBothTagsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        Set<Tag> multipleTags = Set.of(new Tag("buyer"), new Tag("seller"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(multipleTags);
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(BENSON), model.getFilteredPersonList());
+    }
 
     @Test
     public void toStringMethod() {
@@ -131,5 +170,12 @@ public class FilterCommandTest {
      */
     private RemarkContainsKeyphrasePredicate prepareRemarkPredicate(String userInput) {
         return new RemarkContainsKeyphrasePredicate(userInput);
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagsMatchPredicate}.
+     */
+    private TagsMatchPredicate prepareRemarkPredicate(Set<Tag> userInput) {
+        return new TagsMatchPredicate(userInput);
     }
 }

--- a/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
@@ -50,13 +50,24 @@ public class FilterCommandParserTest {
     }
 
     @Test
+    void parse_invalidArgsWithTag_throwsParseException() {
+        String userInput = " t/customer";
+        assertParseFailure(parser, userInput, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
     void parse_validArgsWithTwoTags_returnsFilterCommand() {
-        String userInput = " t/Buyer t/Seller";
+        String userInput = " t/Buyer t/SELLER";
         Set<Tag> predicateTags = Set.of(new Tag("buyer"), new Tag("seller"));
         FilterCommand expectedCommand = new FilterCommand(new TagsMatchPredicate(predicateTags));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
+    @Test
+    void parse_oneValidOneInvalidTag_throwsParseException() {
+        String userInput = " t/Buyer t/customer";
+        assertParseFailure(parser, userInput, Tag.MESSAGE_CONSTRAINTS);
+    }
     @Test
     void parse_validArgsWithThreeTags_throwsParseException() {
         String userInput = " t/Buyer t/Seller t/Buyer";

--- a/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
@@ -2,8 +2,10 @@ package seedu.realodex.logic.parser;
 
 import static seedu.realodex.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.realodex.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +13,10 @@ import seedu.realodex.logic.Messages;
 import seedu.realodex.logic.commands.FilterCommand;
 import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.RemarkContainsKeyphrasePredicate;
+import seedu.realodex.model.person.predicates.TagsMatchPredicate;
+import seedu.realodex.model.tag.Tag;
+
+import java.util.Set;
 
 public class FilterCommandParserTest {
 
@@ -33,6 +39,34 @@ public class FilterCommandParserTest {
         String userInput = " r/Loves cats";
         FilterCommand expectedCommand = new FilterCommand(new RemarkContainsKeyphrasePredicate("Loves cats"));
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    void parse_validArgsWithTag_returnsFilterCommand() {
+        String userInput = " t/buyer";
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"));
+        FilterCommand expectedCommand = new FilterCommand(new TagsMatchPredicate(predicateTags));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    void parse_validArgsWithTwoTags_returnsFilterCommand() {
+        String userInput = " t/Buyer t/Seller";
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"), new Tag("seller"));
+        FilterCommand expectedCommand = new FilterCommand(new TagsMatchPredicate(predicateTags));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    void parse_validArgsWithThreeTags_throwsParseException() {
+        String userInput = " t/Buyer t/Seller t/Buyer";
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TAG));
+    }
+
+    @Test
+    void parse_invalidTagFormat_throwsParseException() {
+        String userInput = " t/Buyer$";
+        assertThrows(IllegalArgumentException.class, () -> new Tag(userInput));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.realodex.logic.Messages;
 import seedu.realodex.logic.commands.FilterCommand;
+import seedu.realodex.model.person.Name;
 import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.RemarkContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.TagsMatchPredicate;
@@ -32,6 +33,11 @@ public class FilterCommandParserTest {
         String userInput = " n/Alice";
         FilterCommand expectedCommand = new FilterCommand(new NameContainsKeyphrasePredicate("Alice"));
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    void parse_invalidArgsWithName_throwsParseException() {
+        assertParseFailure(parser, " n/#$@%^", Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/FilterCommandParserTest.java
@@ -7,6 +7,8 @@ import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseFailu
 import static seedu.realodex.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.realodex.testutil.Assert.assertThrows;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.realodex.logic.Messages;
@@ -15,8 +17,6 @@ import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.RemarkContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.TagsMatchPredicate;
 import seedu.realodex.model.tag.Tag;
-
-import java.util.Set;
 
 public class FilterCommandParserTest {
 

--- a/src/test/java/seedu/realodex/logic/parser/PrefixCheckerTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/PrefixCheckerTest.java
@@ -137,6 +137,14 @@ public class PrefixCheckerTest {
     }
 
     @Test
+    public void isDuplicatePrefix_nullPrefix_assertsError() {
+        String argsString = " n/John Doe n/Jane Doe ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertThrows(AssertionError.class, () -> prefixChecker.isDuplicatePrefix(null));
+    }
+    @Test
     public void isDuplicatePrefix_regularPrefixWithDuplicates_returnsTrue() {
         String argsString = " n/John Doe n/Jane Doe ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
@@ -173,15 +181,39 @@ public class PrefixCheckerTest {
     }
 
     @Test
+    public void isSpecialCasePrefix_nullPrefix_assertsError() {
+        PrefixChecker prefixChecker = new PrefixChecker(new ArgumentMultimap());
+        assertThrows(AssertionError.class, () -> prefixChecker.isSpecialCasePrefix(null));
+    }
+
+    @Test
     public void isSpecialCasePrefix_tagPrefix_returnsTrue() {
         PrefixChecker prefixChecker = new PrefixChecker(new ArgumentMultimap());
         assertTrue(prefixChecker.isSpecialCasePrefix(PREFIX_TAG));
     }
 
     @Test
-    public void isSpecialCasePrefix_nonTagPrefix_returnsFalse() {
-        PrefixChecker prefixChecker = new PrefixChecker(new ArgumentMultimap());
-        assertFalse(prefixChecker.isSpecialCasePrefix(PREFIX_NAME));
+    public void isPrefixPresent_presentPrefix_returnsTrue() {
+        String argsString = " n/John Doe r/has 3 cats. ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME, PREFIX_REMARK);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+        assertTrue(prefixChecker.isPrefixPresent(PREFIX_NAME));
+    }
+
+    @Test
+    public void isPrefixPresent_nonPresentPrefix_returnsTrue() {
+        String argsString = " n/John Doe ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME, PREFIX_REMARK);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+        assertFalse(prefixChecker.isPrefixPresent(PREFIX_REMARK));
+    }
+
+    @Test
+    public void isPrefixPresent_nullPrefix_assertsError() {
+        String argsString = " n/John Doe ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME, PREFIX_REMARK);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+        assertThrows(AssertionError.class, () -> prefixChecker.isPrefixPresent(null));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/PrefixCheckerTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/PrefixCheckerTest.java
@@ -50,7 +50,7 @@ public class PrefixCheckerTest {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME, PREFIX_EMAIL);
         PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
 
-        assertTrue(prefixChecker.moreThanOnePrefixPresent(PREFIX_NAME, PREFIX_EMAIL));
+        assertTrue(prefixChecker.moreThanOnePrefixTypePresent(PREFIX_NAME, PREFIX_EMAIL));
     }
 
     @Test
@@ -59,7 +59,7 @@ public class PrefixCheckerTest {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
         PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
 
-        assertFalse(prefixChecker.moreThanOnePrefixPresent(PREFIX_NAME, PREFIX_EMAIL));
+        assertFalse(prefixChecker.moreThanOnePrefixTypePresent(PREFIX_NAME, PREFIX_EMAIL));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/PrefixCheckerTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/PrefixCheckerTest.java
@@ -10,6 +10,7 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.realodex.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ public class PrefixCheckerTest {
     }
 
     @Test
-    public void moreThanOnePrefixPresent_withMultiplePrefixes_returnsTrue() {
+    public void moreThanOnePrefixTypePresent_withMultiplePrefixes_returnsTrue() {
         String argsString = " n/John Doe e/johnd@example.com ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME, PREFIX_EMAIL);
         PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
@@ -54,7 +55,16 @@ public class PrefixCheckerTest {
     }
 
     @Test
-    public void moreThanOnePrefixPresent_withSinglePrefix_returnsFalse() {
+    public void moreThanOnePrefixTypePresent_withMultipleSamePrefixType_returnsFalse() {
+        String argsString = " t/buyer t/seller";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertFalse(prefixChecker.moreThanOnePrefixTypePresent(PREFIX_NAME, PREFIX_EMAIL));
+    }
+
+    @Test
+    public void moreThanOnePrefixTypePresent_withSinglePrefix_returnsFalse() {
         String argsString = " n/John Doe ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
         PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
@@ -91,6 +101,24 @@ public class PrefixCheckerTest {
     }
 
     @Test
+    public void checkNoDuplicatePrefix_upToTwoTagPrefixes_doesNotThrowException() {
+        String argsString = " t/buyer t/seller ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_TAG);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertDoesNotThrow(() -> prefixChecker.checkNoDuplicatePrefix(PREFIX_TAG));
+    }
+
+    @Test
+    public void checkNoDuplicatePrefix_moreThanTwoTagPrefixes_throwsParseException() {
+        String argsString = " t/buyer t/seller t/buyer ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_TAG);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertThrows(ParseException.class, () -> prefixChecker.checkNoDuplicatePrefix(PREFIX_TAG));
+    }
+
+    @Test
     public void checkNoDuplicatePrefix_oneDuplicate_throwsParseException() {
         String argsString = " n/John Doe n/Jane Doe ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
@@ -106,6 +134,54 @@ public class PrefixCheckerTest {
         PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
 
         assertThrows(ParseException.class, () -> prefixChecker.checkNoDuplicatePrefix(PREFIX_NAME, PREFIX_EMAIL));
+    }
+
+    @Test
+    public void isDuplicatePrefix_regularPrefixWithDuplicates_returnsTrue() {
+        String argsString = " n/John Doe n/Jane Doe ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertTrue(prefixChecker.isDuplicatePrefix(PREFIX_NAME));
+    }
+
+    @Test
+    public void isDuplicatePrefix_regularPrefixWithoutDuplicates_returnsFalse() {
+        String argsString = " n/John Doe ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_NAME);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertFalse(prefixChecker.isDuplicatePrefix(PREFIX_NAME));
+    }
+
+    @Test
+    public void isDuplicatePrefix_specialCasePrefixWithAllowedDuplicates_returnsFalse() {
+        String argsString = " t/buyer t/seller ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_TAG);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertFalse(prefixChecker.isDuplicatePrefix(PREFIX_TAG));
+    }
+
+    @Test
+    public void isDuplicatePrefix_specialCasePrefixExceedingAllowedDuplicates_returnsTrue() {
+        String argsString = " t/buyer t/seller t/buyer ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, PREFIX_TAG);
+        PrefixChecker prefixChecker = new PrefixChecker(argMultimap);
+
+        assertTrue(prefixChecker.isDuplicatePrefix(PREFIX_TAG), "More than two PREFIX_TAG should return true.");
+    }
+
+    @Test
+    public void isSpecialCasePrefix_tagPrefix_returnsTrue() {
+        PrefixChecker prefixChecker = new PrefixChecker(new ArgumentMultimap());
+        assertTrue(prefixChecker.isSpecialCasePrefix(PREFIX_TAG));
+    }
+
+    @Test
+    public void isSpecialCasePrefix_nonTagPrefix_returnsFalse() {
+        PrefixChecker prefixChecker = new PrefixChecker(new ArgumentMultimap());
+        assertFalse(prefixChecker.isSpecialCasePrefix(PREFIX_NAME));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -7,6 +7,8 @@ import static seedu.realodex.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.realodex.testutil.Assert.assertThrows;
 import static seedu.realodex.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.realodex.logic.commands.AddCommand;
@@ -28,8 +30,6 @@ import seedu.realodex.model.tag.Tag;
 import seedu.realodex.testutil.EditPersonDescriptorBuilder;
 import seedu.realodex.testutil.PersonBuilder;
 import seedu.realodex.testutil.PersonUtil;
-
-import java.util.Set;
 
 public class RealodexParserTest {
 

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -23,9 +23,13 @@ import seedu.realodex.model.person.Name;
 import seedu.realodex.model.person.Person;
 import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.RemarkContainsKeyphrasePredicate;
+import seedu.realodex.model.person.predicates.TagsMatchPredicate;
+import seedu.realodex.model.tag.Tag;
 import seedu.realodex.testutil.EditPersonDescriptorBuilder;
 import seedu.realodex.testutil.PersonBuilder;
 import seedu.realodex.testutil.PersonUtil;
+
+import java.util.Set;
 
 public class RealodexParserTest {
 
@@ -91,6 +95,14 @@ public class RealodexParserTest {
         FilterCommand command = (FilterCommand) parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " r/" + keyphrase);
         assertEquals(new FilterCommand(new RemarkContainsKeyphrasePredicate(keyphrase)), command);
+    }
+
+    @Test
+    public void parseCommand_filterByTags() throws Exception {
+        Set<Tag> tagString = Set.of(new Tag("buyer"), new Tag("seller"));
+        FilterCommand command = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD + " t/buyer " + "t/seller");
+        assertEquals(new FilterCommand(new TagsMatchPredicate(tagString)), command);
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -98,7 +98,22 @@ public class RealodexParserTest {
     }
 
     @Test
-    public void parseCommand_filterByTags() throws Exception {
+    public void parseCommand_filterByBuyerTag() throws Exception {
+        Set<Tag> tagString = Set.of(new Tag("buyer"));
+        FilterCommand command = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD + " t/buyer ");
+        assertEquals(new FilterCommand(new TagsMatchPredicate(tagString)), command);
+    }
+
+    @Test
+    public void parseCommand_filterBySellerTags() throws Exception {
+        Set<Tag> tagString = Set.of(new Tag("seller"));
+        FilterCommand command = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD + " t/seller");
+        assertEquals(new FilterCommand(new TagsMatchPredicate(tagString)), command);
+    }
+    @Test
+    public void parseCommand_filterByBuyerAndSellerTags() throws Exception {
         Set<Tag> tagString = Set.of(new Tag("buyer"), new Tag("seller"));
         FilterCommand command = (FilterCommand) parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " t/buyer " + "t/seller");

--- a/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
@@ -8,6 +8,7 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,9 +16,12 @@ import seedu.realodex.logic.commands.FilterCommand;
 import seedu.realodex.logic.parser.Prefix;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 import seedu.realodex.model.person.Person;
+import seedu.realodex.model.person.Person;
 import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.PredicateProducer;
 import seedu.realodex.model.person.predicates.RemarkContainsKeyphrasePredicate;
+import seedu.realodex.model.person.predicates.TagsMatchPredicate;
+import seedu.realodex.model.tag.Tag;
 import seedu.realodex.testutil.PersonBuilder;
 
 class PredicateProducerTest {
@@ -60,6 +64,22 @@ class PredicateProducerTest {
 
         Person bob = new PersonBuilder().withName("Bob").withTags("buyer", "seller").build();
         assertTrue(predicateProducer.createPredicate(PREFIX_TAG, keyphrases).test(bob));
+    }
+
+    @Test
+    void createMatchTagPredicate_validTagStrings_assertionErrorWhenInvalidPrefix() {
+        PredicateProducer predicateProducer = new PredicateProducer();
+        List<String> keyphrases = List.of("buyer", "seller");
+        Set<Tag> tagString = Set.of(new Tag("buyer"), new Tag("seller"));
+        assertEquals(predicateProducer.createMatchTagsPredicate(keyphrases), new TagsMatchPredicate(tagString));
+    }
+
+    @Test
+    void createMatchTagPredicate_invalidTagString_assertionErrorWhenInvalidPrefix() {
+        PredicateProducer predicateProducer = new PredicateProducer();
+        List<String> keyphrases = List.of("customer");
+
+        assertThrows(AssertionError.class, () -> predicateProducer.createMatchTagsPredicate(keyphrases));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
@@ -1,10 +1,13 @@
 package seedu.realodex.model.person.predicate;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +25,7 @@ class PredicateProducerTest {
     @Test
     void createPredicate_validNamePrefix_createsCorrectPredicate() throws ParseException {
         PredicateProducer predicateProducer = new PredicateProducer();
-        String keyphrase = "Alice";
+        List<String> keyphrase = List.of("Alice");
 
         Person alice = new PersonBuilder().withName("Alice").withRemark("She is a lice").build();
         assertEquals(predicateProducer.createPredicate(PREFIX_NAME, keyphrase),
@@ -33,7 +36,7 @@ class PredicateProducerTest {
     @Test
     void createPredicate_validRemarkPrefix_createsCorrectPredicate() throws ParseException {
         PredicateProducer predicateProducer = new PredicateProducer();
-        String keyphrase = "She is a lice";
+        List<String> keyphrase = List.of("She is a lice");
 
         Person alice = new PersonBuilder().withName("Alice").withRemark("She is a lice").build();
         assertEquals(predicateProducer.createPredicate(PREFIX_REMARK, keyphrase),
@@ -42,9 +45,27 @@ class PredicateProducerTest {
     }
 
     @Test
+    void createPredicate_validTagPrefix_createsCorrectPredicate() throws ParseException {
+        PredicateProducer predicateProducer = new PredicateProducer();
+        List<String> keyphrases = List.of("buyer");
+
+        Person bob = new PersonBuilder().withName("Bob").withTags("buyer").build();
+        assertTrue(predicateProducer.createPredicate(PREFIX_TAG, keyphrases).test(bob));
+    }
+
+    @Test
+    void createPredicate_validMultipleTagPrefixes_createsCorrectPredicate() throws ParseException {
+        PredicateProducer predicateProducer = new PredicateProducer();
+        List<String> keyphrases = List.of("buyer", "seller");
+
+        Person bob = new PersonBuilder().withName("Bob").withTags("buyer", "seller").build();
+        assertTrue(predicateProducer.createPredicate(PREFIX_TAG, keyphrases).test(bob));
+    }
+
+    @Test
     void createPredicate_emptyKeyphrase_throwsParseException() {
         PredicateProducer predicateProducer = new PredicateProducer();
-        String keyphrase = "";
+        List<String> keyphrase = List.of("");
 
         ParseException exception = assertThrows(ParseException.class, () ->
                 predicateProducer.createPredicate(PREFIX_NAME, keyphrase));
@@ -56,10 +77,11 @@ class PredicateProducerTest {
     void createPredicate_assertionErrorWhenInvalidPrefix() {
         PredicateProducer predicateProducer = new PredicateProducer();
         Prefix unhandledPrefix = new Prefix("unhandled/");
+        List<String> keyphrase = List.of("keyphrase");
 
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
 
-        assertThrows(AssertionError.class, () -> predicateProducer.createPredicate(unhandledPrefix, "keyphrase"));
+        assertThrows(AssertionError.class, () -> predicateProducer.createPredicate(unhandledPrefix, keyphrase));
     }
 
 }

--- a/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
@@ -1,13 +1,13 @@
 package seedu.realodex.model.person.predicate;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/PredicateProducerTest.java
@@ -16,7 +16,6 @@ import seedu.realodex.logic.commands.FilterCommand;
 import seedu.realodex.logic.parser.Prefix;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 import seedu.realodex.model.person.Person;
-import seedu.realodex.model.person.Person;
 import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.PredicateProducer;
 import seedu.realodex.model.person.predicates.RemarkContainsKeyphrasePredicate;

--- a/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -19,17 +20,20 @@ public class TagsMatchPredicateTest {
 
     @Test
     public void equals() {
-        String firstPredicateKeyphrase = "first";
-        String secondPredicateKeyphrase = "first second";
+        Set<Tag> firstTagSet = Set.of(new Tag("buyer"));
+        Set<Tag> secondTagSet = Set.of(new Tag("seller"));
+        Set<Tag> thirdTagSet = Set.of(new Tag("buyer"), new Tag("seller"));
 
-        NameContainsKeyphrasePredicate firstPredicate = new NameContainsKeyphrasePredicate(firstPredicateKeyphrase);
-        NameContainsKeyphrasePredicate secondPredicate = new NameContainsKeyphrasePredicate(secondPredicateKeyphrase);
+
+        TagsMatchPredicate firstPredicate = new TagsMatchPredicate(firstTagSet);
+        TagsMatchPredicate secondPredicate = new TagsMatchPredicate(secondTagSet);
+        TagsMatchPredicate thirdPredicate = new TagsMatchPredicate(thirdTagSet);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameContainsKeyphrasePredicate firstPredicateCopy = new NameContainsKeyphrasePredicate(firstPredicateKeyphrase);
+        TagsMatchPredicate firstPredicateCopy = new TagsMatchPredicate(firstTagSet);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -40,6 +44,9 @@ public class TagsMatchPredicateTest {
 
         // different person -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
+
+        // stricter vs less-strict predicate
+        assertFalse(firstPredicate.equals(thirdPredicate));
     }
 
     @Test

--- a/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
@@ -1,0 +1,113 @@
+package seedu.realodex.model.person.predicate;
+
+import org.junit.jupiter.api.Test;
+import seedu.realodex.model.person.Person;
+import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
+import seedu.realodex.model.person.predicates.TagsMatchPredicate;
+import seedu.realodex.model.tag.Tag;
+import seedu.realodex.testutil.PersonBuilder;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TagsMatchPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyphrase = "first";
+        String secondPredicateKeyphrase = "first second";
+
+        NameContainsKeyphrasePredicate firstPredicate = new NameContainsKeyphrasePredicate(firstPredicateKeyphrase);
+        NameContainsKeyphrasePredicate secondPredicate = new NameContainsKeyphrasePredicate(secondPredicateKeyphrase);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        NameContainsKeyphrasePredicate firstPredicateCopy = new NameContainsKeyphrasePredicate(firstPredicateKeyphrase);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    void test_personTagsMatchPredicateTags_returnsTrue() {
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(predicateTags);
+
+        Person person = new PersonBuilder().withTags("buyer").build();
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    void test_personMultipleTagsIncludingPredicateTags_returnsTrue() {
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(predicateTags);
+
+        Person person = new PersonBuilder().withTags("buyer", "seller").build();
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    void test_personMultipleTagsIncludingMultiplePredicateTags_returnsTrue() {
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"), new Tag("seller"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(predicateTags);
+
+        Person person = new PersonBuilder().withTags("buyer", "seller").build();
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    void test_personNoTagsDontMatchPredicateTags_returnsFalse() {
+
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(predicateTags);
+
+        Person person = new PersonBuilder().withTags("").build();
+
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    void test_personTagsDontMatchPredicateTags_returnsFalse() {
+
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(predicateTags);
+
+        Person person = new PersonBuilder().withTags("seller").build();
+
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    void test_personTagsDontMatchMultiplePredicateTags_returnsFalse() {
+
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"), new Tag( "seller"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(predicateTags);
+
+        Person person = new PersonBuilder().withTags("seller").build();
+
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Set<Tag> tagSet = Set.of(new Tag("buyer"), new Tag( "seller"));
+        TagsMatchPredicate predicate = new TagsMatchPredicate(tagSet);
+        String expected = TagsMatchPredicate.class.getCanonicalName() + "{Tag Set=" + tagSet + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
@@ -4,13 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.realodex.model.person.Person;
-import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.TagsMatchPredicate;
 import seedu.realodex.model.tag.Tag;
 import seedu.realodex.testutil.PersonBuilder;

--- a/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
+++ b/src/test/java/seedu/realodex/model/person/predicate/TagsMatchPredicateTest.java
@@ -1,17 +1,19 @@
 package seedu.realodex.model.person.predicate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.realodex.model.person.Person;
 import seedu.realodex.model.person.predicates.NameContainsKeyphrasePredicate;
 import seedu.realodex.model.person.predicates.TagsMatchPredicate;
 import seedu.realodex.model.tag.Tag;
 import seedu.realodex.testutil.PersonBuilder;
 
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TagsMatchPredicateTest {
 
@@ -95,7 +97,7 @@ public class TagsMatchPredicateTest {
     @Test
     void test_personTagsDontMatchMultiplePredicateTags_returnsFalse() {
 
-        Set<Tag> predicateTags = Set.of(new Tag("buyer"), new Tag( "seller"));
+        Set<Tag> predicateTags = Set.of(new Tag("buyer"), new Tag("seller"));
         TagsMatchPredicate predicate = new TagsMatchPredicate(predicateTags);
 
         Person person = new PersonBuilder().withTags("seller").build();
@@ -105,7 +107,7 @@ public class TagsMatchPredicateTest {
 
     @Test
     public void toStringMethod() {
-        Set<Tag> tagSet = Set.of(new Tag("buyer"), new Tag( "seller"));
+        Set<Tag> tagSet = Set.of(new Tag("buyer"), new Tag("seller"));
         TagsMatchPredicate predicate = new TagsMatchPredicate(tagSet);
         String expected = TagsMatchPredicate.class.getCanonicalName() + "{Tag Set=" + tagSet + "}";
         assertEquals(expected, predicate.toString());


### PR DESCRIPTION
# Description
This PR introduces tag-based filtering functionality in our application. 

# Key Changes
- Implement Filter by Tag: Introduced the ability to filter entities based on tags
- Implement filter by **multiple** tags
- Create TagsMatchPredicateTest

# Bug Fixes:
- Fix Invalid Tag Error Handling: Addressed a bug where errors were not being thrown as expected for invalid tag inputs, ensuring the application behaves predictably in error scenarios
- Fix Prefix Handling: Resolved an issue where the application allowed more than one prefix type in filter queries, which could lead to ambiguous or unintended filtering behavior 

# Testing:
- Add Integration Testing for Filtering by Tags 
- Include More Testing for Filtering by Tags
- Add Testing for Filtering by Invalid Tags
- Developed unit tests for the TagsMatchPredicate class, validating its behavior and logic in isolation 
- Integration testing for FilterParser and RealodexParser to capture new filter by tag functionality

Fix #169, fix #171, fix #167, fix #117