### PR TITLE
Fix the logic for checking valid dates and tests

### DIFF
--- a/src/main/java/seedu/realodex/model/person/Birthday.java
+++ b/src/main/java/seedu/realodex/model/person/Birthday.java
@@ -69,37 +69,43 @@ public class Birthday {
             formatter.setLenient(false);
             Date parsedDate = formatter.parse(birthday.trim());
             Date currentDate = new Date();
-
-            if (!(parsedDate.after(currentDate)) && defensiveCheckIsValidBirthday(parsedDate)) {
+            if (!(parsedDate.after(currentDate)) && defensiveCheckIsValidBirthday(birthday)) {
                 return true;
             }
             return false;
-
         } catch (ParseException e) {
             return false;
         }
     }
 
-    private static boolean defensiveCheckIsValidBirthday(Date parsedDate) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(parsedDate);
-        int year = cal.get(Calendar.YEAR);
-        int month = cal.get(Calendar.MONTH);
-        int day = cal.get(Calendar.DAY_OF_MONTH);
+    protected static boolean defensiveCheckIsValidBirthday(String birthday) {
+        try {
+            SimpleDateFormat formatter = new SimpleDateFormat(INPUT_DATE_PATTERN, Locale.ENGLISH);
+            formatter.setLenient(false);
+            Date parsedDate = formatter.parse(birthday.trim());
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(parsedDate);
+            int year = cal.get(Calendar.YEAR);
+            int month = cal.get(Calendar.MONTH);
+            int day = cal.get(Calendar.DAY_OF_MONTH);
 
-        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
-        if (!(year >= 1000 && year <= currentYear)) {
+            int currentYear = Calendar.getInstance().get(Calendar.YEAR);
+            if (!(year >= 1000 && year <= currentYear)) {
+                return false;
+            }
+            if (!(month >= Calendar.JANUARY && month <= Calendar.DECEMBER)) {
+                return false;
+            }
+            int maxDaysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
+            if (!(day >= 1 && day <= maxDaysInMonth)) {
+                return false;
+            }
+            return true;
+        } catch (ParseException e) {
             return false;
         }
-        if (!(month >= Calendar.JANUARY && month <= Calendar.DECEMBER)) {
-            return false;
-        }
-        int maxDaysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
-        if (!(day >= 1 && day <= maxDaysInMonth)) {
-            return false;
-        }
-        return true;
     }
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/realodex/model/person/Birthday.java
+++ b/src/main/java/seedu/realodex/model/person/Birthday.java
@@ -69,38 +69,10 @@ public class Birthday {
             formatter.setLenient(false);
             Date parsedDate = formatter.parse(birthday.trim());
             Date currentDate = new Date();
-            if (!(parsedDate.after(currentDate)) && defensiveCheckIsValidBirthday(birthday)) {
+            if (!(parsedDate.after(currentDate))) {
                 return true;
             }
             return false;
-        } catch (ParseException e) {
-            return false;
-        }
-    }
-
-    protected static boolean defensiveCheckIsValidBirthday(String birthday) {
-        try {
-            SimpleDateFormat formatter = new SimpleDateFormat(INPUT_DATE_PATTERN, Locale.ENGLISH);
-            formatter.setLenient(false);
-            Date parsedDate = formatter.parse(birthday.trim());
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(parsedDate);
-            int year = cal.get(Calendar.YEAR);
-            int month = cal.get(Calendar.MONTH);
-            int day = cal.get(Calendar.DAY_OF_MONTH);
-
-            int currentYear = Calendar.getInstance().get(Calendar.YEAR);
-            if (!(year >= 1000 && year <= currentYear)) {
-                return false;
-            }
-            if (!(month >= Calendar.JANUARY && month <= Calendar.DECEMBER)) {
-                return false;
-            }
-            int maxDaysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
-            if (!(day >= 1 && day <= maxDaysInMonth)) {
-                return false;
-            }
-            return true;
         } catch (ParseException e) {
             return false;
         }

--- a/src/main/java/seedu/realodex/model/person/Birthday.java
+++ b/src/main/java/seedu/realodex/model/person/Birthday.java
@@ -3,7 +3,6 @@ package seedu.realodex.model.person;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Optional;

--- a/src/main/java/seedu/realodex/model/person/Birthday.java
+++ b/src/main/java/seedu/realodex/model/person/Birthday.java
@@ -17,11 +17,12 @@ import seedu.realodex.commons.core.LogsCenter;
 public class Birthday {
 
     public static final String INPUT_DATE_PATTERN = "ddMMMyyyy";
-    public static final String MESSAGE_CONSTRAINTS = "Birthday should be in " + INPUT_DATE_PATTERN + " format\nDate "
-            + "should also not be in future years and no earlier than year 1000!";
+    public static final String MESSAGE_CONSTRAINTS = "Birthday should be in " + INPUT_DATE_PATTERN + " format\n"
+            + "A valid date should be given, and it cannot be in the future and no earlier than year 1000.";
     public static final SimpleDateFormat INPUT_DATE_FORMATTER = new SimpleDateFormat(INPUT_DATE_PATTERN);
     public static final DateFormat DATE_FORMAT = DateFormat.getDateInstance(DateFormat.MEDIUM);
     private static final Logger logger = LogsCenter.getLogger(Birthday.class);
+
     public final Optional<Date> birthday;
     /**
      * Constructs a {@code Birthday}.
@@ -67,27 +68,37 @@ public class Birthday {
             SimpleDateFormat formatter = new SimpleDateFormat(INPUT_DATE_PATTERN, Locale.ENGLISH);
             formatter.setLenient(false);
             Date parsedDate = formatter.parse(birthday.trim());
+            Date currentDate = new Date();
 
-            // Validate the month (1-12)
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(parsedDate);
-            int month = cal.get(Calendar.MONTH);
-            if (month >= Calendar.JANUARY && month <= Calendar.DECEMBER) {
-                // Validate the day (1-31)
-                int day = cal.get(Calendar.DAY_OF_MONTH);
-                if (day >= 1 && day <= 31) {
-                    // Validate the year (e.g., not in the future)
-                    int currentYear = Calendar.getInstance().get(Calendar.YEAR);
-                    int year = cal.get(Calendar.YEAR);
-                    if (year >= 1000 && year <= currentYear) {
-                        return true;
-                    }
-                }
+            if (!(parsedDate.after(currentDate)) && defensiveCheckIsValidBirthday(parsedDate)) {
+                return true;
             }
             return false;
+
         } catch (ParseException e) {
             return false;
         }
+    }
+
+    private static boolean defensiveCheckIsValidBirthday(Date parsedDate) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(parsedDate);
+        int year = cal.get(Calendar.YEAR);
+        int month = cal.get(Calendar.MONTH);
+        int day = cal.get(Calendar.DAY_OF_MONTH);
+
+        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
+        if (!(year >= 1000 && year <= currentYear)) {
+            return false;
+        }
+        if (!(month >= Calendar.JANUARY && month <= Calendar.DECEMBER)) {
+            return false;
+        }
+        int maxDaysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
+        if (!(day >= 1 && day <= maxDaysInMonth)) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/test/java/seedu/realodex/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/realodex/model/person/BirthdayTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.realodex.testutil.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
+import org.junit.jupiter.api.Test;
 
 public class BirthdayTest {
 
@@ -31,6 +33,7 @@ public class BirthdayTest {
 
         // invalid parts
         assertFalse(Birthday.isValidBirthday("29Feb2023")); // not a leap year
+        assertFalse(Birthday.isValidBirthday("31June2023")); // June does not have 31 days
         assertFalse(Birthday.isValidBirthday("1-jan-2001")); // not supposed to have '-'
 
         // valid date
@@ -41,7 +44,18 @@ public class BirthdayTest {
         // invalid dates
         assertFalse(Birthday.isValidBirthday("01May2009233"));
         assertFalse(Birthday.isValidBirthday("0"));
-        assertFalse(Birthday.isValidBirthday("1jan2032")); //cant be in future
+
+        // creating future dates
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);
+        LocalDate futureDate = today.plusYears(10);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("ddMMyyyy");
+        String tomorrowFormatted = tomorrow.format(formatter);
+        String futureFormatted = futureDate.format(formatter);
+
+        // future dates
+        assertFalse(Birthday.isValidBirthday(tomorrowFormatted)); //cant be in future days
+        assertFalse(Birthday.isValidBirthday(futureFormatted)); //cant be in future years
 
     }
 

--- a/src/test/java/seedu/realodex/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/realodex/model/person/BirthdayTest.java
@@ -8,6 +8,7 @@ import static seedu.realodex.testutil.Assert.assertThrows;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+
 import org.junit.jupiter.api.Test;
 
 public class BirthdayTest {
@@ -18,11 +19,11 @@ public class BirthdayTest {
     }
 
     @Test
-    public void isValidBirthday() {
-        // null email
+    public void isValidBirthday_test() {
+        // null date
         assertThrows(NullPointerException.class, () -> Birthday.isValidBirthday(null));
 
-        // blank email
+        // blank dates
         assertTrue(Birthday.isValidBirthday("")); // empty string
         assertTrue(Birthday.isValidBirthday(" ")); // spaces only
 
@@ -60,7 +61,44 @@ public class BirthdayTest {
     }
 
     @Test
-    public void equals() {
+    public void defensiveCheckIsValidBirthday_test() {
+        // null date
+        assertThrows(NullPointerException.class, () -> Birthday.defensiveCheckIsValidBirthday(null));
+
+        // missing parts
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("1")); // missing month
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("31June")); // missing year
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("June2002")); // missing day
+
+        // invalid parts
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("29Feb2023")); // not a leap year
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("31June2023")); // June does not have 31 days
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("1-jan-2001")); // not supposed to have '-'
+
+        // valid date
+        assertTrue(Birthday.defensiveCheckIsValidBirthday("29Feb2024")); // leap year
+        assertTrue(Birthday.defensiveCheckIsValidBirthday("12May2003"));
+        assertTrue(Birthday.defensiveCheckIsValidBirthday("08Aug1888"));
+
+        // invalid dates
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("01May2009233"));
+        assertFalse(Birthday.defensiveCheckIsValidBirthday("0"));
+
+        // creating future dates
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);
+        LocalDate futureDate = today.plusYears(10);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("ddMMyyyy");
+        String tomorrowFormatted = tomorrow.format(formatter);
+        String futureFormatted = futureDate.format(formatter);
+
+        // future dates
+        assertFalse(Birthday.defensiveCheckIsValidBirthday(tomorrowFormatted)); //cant be in future days
+        assertFalse(Birthday.defensiveCheckIsValidBirthday(futureFormatted)); //cant be in future years
+    }
+
+    @Test
+    public void equals_test() {
         Birthday birthday = new Birthday("14mar1706"); // pi day!
 
         // same values -> returns true
@@ -80,7 +118,7 @@ public class BirthdayTest {
     }
 
     @Test
-    public void birthdayDefaultConstructor_equalsDefault() {
+    public void birthdayDefaultConstructor_equalsDefault_test() {
         Birthday defaultBirthday = new Birthday();
         Birthday birthdayWithDefaultValue = new Birthday("01May2023");
         assertEquals(defaultBirthday, birthdayWithDefaultValue);

--- a/src/test/java/seedu/realodex/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/realodex/model/person/BirthdayTest.java
@@ -8,7 +8,6 @@ import static seedu.realodex.testutil.Assert.assertThrows;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-
 import org.junit.jupiter.api.Test;
 
 public class BirthdayTest {

--- a/src/test/java/seedu/realodex/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/realodex/model/person/BirthdayTest.java
@@ -60,43 +60,6 @@ public class BirthdayTest {
     }
 
     @Test
-    public void defensiveCheckIsValidBirthday_test() {
-        // null date
-        assertThrows(NullPointerException.class, () -> Birthday.defensiveCheckIsValidBirthday(null));
-
-        // missing parts
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("1")); // missing month
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("31June")); // missing year
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("June2002")); // missing day
-
-        // invalid parts
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("29Feb2023")); // not a leap year
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("31June2023")); // June does not have 31 days
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("1-jan-2001")); // not supposed to have '-'
-
-        // valid date
-        assertTrue(Birthday.defensiveCheckIsValidBirthday("29Feb2024")); // leap year
-        assertTrue(Birthday.defensiveCheckIsValidBirthday("12May2003"));
-        assertTrue(Birthday.defensiveCheckIsValidBirthday("08Aug1888"));
-
-        // invalid dates
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("01May2009233"));
-        assertFalse(Birthday.defensiveCheckIsValidBirthday("0"));
-
-        // creating future dates
-        LocalDate today = LocalDate.now();
-        LocalDate tomorrow = today.plusDays(1);
-        LocalDate futureDate = today.plusYears(10);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("ddMMyyyy");
-        String tomorrowFormatted = tomorrow.format(formatter);
-        String futureFormatted = futureDate.format(formatter);
-
-        // future dates
-        assertFalse(Birthday.defensiveCheckIsValidBirthday(tomorrowFormatted)); //cant be in future days
-        assertFalse(Birthday.defensiveCheckIsValidBirthday(futureFormatted)); //cant be in future years
-    }
-
-    @Test
     public void equals_test() {
         Birthday birthday = new Birthday("14mar1706"); // pi day!
 


### PR DESCRIPTION
- Fix the issue where invalid birthdays in the future is only checked against whether it is in future year or not, so the same year but future month will still be valid even if it is not
- Fix the tests that test if the date is in the future with relative dates instead of static ones as the tests will fail once that date is reached
- Fix #199