### PR TITLE
V1.3 case insensitive commands

### DIFF
--- a/src/main/java/seedu/realodex/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/ClearCommand.java
@@ -10,7 +10,7 @@ import seedu.realodex.model.Realodex;
  */
 public class ClearCommand extends Command {
 
-    public static final String COMMAND_WORD = "clearRealodex";
+    public static final String COMMAND_WORD = "clearrealodex";
     public static final String MESSAGE_SUCCESS = "Realodex has been cleared!";
     public static final String MESSAGE_CLEAR_HELP = "Clear Command: Clears all entries in Realodex.\n"
             + "Format: clearRealodex\n";

--- a/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/HelpCommand.java
@@ -24,7 +24,7 @@ public class HelpCommand extends Command {
     private final String command;
 
     public HelpCommand(String command) {
-        this.command = command.trim();
+        this.command = command.trim().toLowerCase();
     }
 
     @Override

--- a/src/main/java/seedu/realodex/logic/parser/RealodexParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/RealodexParser.java
@@ -43,7 +43,7 @@ public class RealodexParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
         //just for checking if help is called so that trimming is possible
@@ -54,10 +54,7 @@ public class RealodexParser {
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        boolean isHelp = false;
-        if (nonFinalArguments.trim().equalsIgnoreCase("help")) {
-            isHelp = true;
-        }
+        boolean isHelp = nonFinalArguments.trim().equalsIgnoreCase("help");
 
         switch (commandWord) {
 

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -181,14 +181,12 @@ public class RealodexParserTest {
     @Test
     public void parseCommand_clear_help() throws Exception {
         assertTrue(parser.parseCommand("clearRealodex help") instanceof HelpCommand);
-        assertTrue(parser.parseCommand("clearrealodex help") instanceof HelpCommand);
-        assertTrue(parser.parseCommand("CLEARREALODEX HELP") instanceof HelpCommand);
-        assertTrue(parser.parseCommand("CLEARREALODEX help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("clearRealodex help".toUpperCase()) instanceof HelpCommand);
+        assertTrue(parser.parseCommand("clearRealodex help".toLowerCase()) instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("clearRealodex");
         assertEquals(parser.parseCommand("clearRealodex help"), expected);
-//        assertEquals(parser.parseCommand("clearrealodex help"), expected);
-//        assertEquals(parser.parseCommand("CLEARREALODEX help"), expected);
-//        assertEquals(parser.parseCommand("CLEARREALODEX HELP"), expected);
+        assertEquals(parser.parseCommand("clearRealodex help".toUpperCase()), expected);
+        assertEquals(parser.parseCommand("clearRealodex help".toLowerCase()), expected);
     }
 
     @Test
@@ -250,13 +248,19 @@ public class RealodexParserTest {
     @Test
     public void parseCommand_sort_help() throws Exception {
         assertTrue(parser.parseCommand("sort help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("sort help".toUpperCase()) instanceof HelpCommand);
+        assertTrue(parser.parseCommand("sOrT HelP") instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("sort");
         assertEquals(parser.parseCommand("sort help"), expected);
+        assertEquals(parser.parseCommand("sort help".toUpperCase()), expected);
+        assertEquals(parser.parseCommand("soRt hElP"), expected);
     }
 
     @Test
     public void parseCommand_sort() throws Exception {
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD) instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD.toUpperCase()) instanceof SortCommand);
+        assertTrue(parser.parseCommand("soRt") instanceof SortCommand);
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/RealodexParserTest.java
@@ -69,12 +69,26 @@ public class RealodexParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+
+        // command in caps
+        EditCommand commandInCaps = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD.toUpperCase() + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), commandInCaps);
+
+        // command mixed cases
+        EditCommand commandMixedCases = (EditCommand) parser.parseCommand("eDiT" + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), commandMixedCases);
     }
 
     @Test
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD.toLowerCase()) instanceof ExitCommand);
+        assertTrue(parser.parseCommand("eXit") instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD.toLowerCase() + " 3") instanceof ExitCommand);
+        assertTrue(parser.parseCommand("eXiT" + " 3") instanceof ExitCommand);
     }
 
     @Test
@@ -83,6 +97,16 @@ public class RealodexParserTest {
         FilterCommand command = (FilterCommand) parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " n/" + keyphrase);
         assertEquals(new FilterCommand(new NameContainsKeyphrasePredicate(keyphrase)), command);
+
+        // command in caps
+        FilterCommand commandInCaps = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD.toUpperCase() + " n/" + keyphrase);
+        assertEquals(new FilterCommand(new NameContainsKeyphrasePredicate(keyphrase)), commandInCaps);
+
+        // command mixed case
+        FilterCommand commandMixedCase = (FilterCommand) parser.parseCommand(
+                "fIlTeR" + " n/" + keyphrase);
+        assertEquals(new FilterCommand(new NameContainsKeyphrasePredicate(keyphrase)), commandMixedCase);
     }
 
     @Test
@@ -91,66 +115,114 @@ public class RealodexParserTest {
         FilterCommand command = (FilterCommand) parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " r/" + keyphrase);
         assertEquals(new FilterCommand(new RemarkContainsKeyphrasePredicate(keyphrase)), command);
+
+        // command in caps
+        FilterCommand commandInCaps = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD.toUpperCase() + " n/" + keyphrase);
+        assertEquals(new FilterCommand(new NameContainsKeyphrasePredicate(keyphrase)), commandInCaps);
+
+        // command mixed case
+        FilterCommand commandMixedCase = (FilterCommand) parser.parseCommand(
+                "fIlTeR" + " n/" + keyphrase);
+        assertEquals(new FilterCommand(new NameContainsKeyphrasePredicate(keyphrase)), commandMixedCase);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD.toUpperCase()) instanceof HelpCommand);
+        assertTrue(parser.parseCommand("hElP") instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD.toUpperCase() + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("HeLp" + " 3") instanceof HelpCommand);
+
     }
 
     @Test
     public void parseCommand_add_help() throws Exception {
         assertTrue(parser.parseCommand("add help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("ADD HELP") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("aDd hElP") instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("add");
         assertEquals(parser.parseCommand("add help"), expected);
+        assertEquals(parser.parseCommand("ADD HELP"), expected);
+        assertEquals(parser.parseCommand("aDd hElP"), expected);
+
     }
 
     @Test
     public void parseCommand_clear_help() throws Exception {
         assertTrue(parser.parseCommand("clearRealodex help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("clearrealodex help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("CLEARREALODEX HELP") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("CLEARREALODEX help") instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("clearRealodex");
         assertEquals(parser.parseCommand("clearRealodex help"), expected);
+//        assertEquals(parser.parseCommand("clearrealodex help"), expected);
+//        assertEquals(parser.parseCommand("CLEARREALODEX help"), expected);
+//        assertEquals(parser.parseCommand("CLEARREALODEX HELP"), expected);
     }
 
     @Test
     public void parseCommand_delete_help() throws Exception {
         assertTrue(parser.parseCommand("delete help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("DELETE HELP") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("dElEtE hElP") instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("delete");
         assertEquals(parser.parseCommand("delete help"), expected);
+        assertEquals(parser.parseCommand("DELETE HELP"), expected);
+        assertEquals(parser.parseCommand("dElEtE hElP"), expected);
+
     }
 
     @Test
     public void parseCommand_edit_help() throws Exception {
         assertTrue(parser.parseCommand("edit help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("edit help".toUpperCase()) instanceof HelpCommand);
+        assertTrue(parser.parseCommand("eDit hElP") instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("edit");
         assertEquals(parser.parseCommand("edit help"), expected);
+        assertEquals(parser.parseCommand("edit help".toUpperCase()), expected);
+        assertEquals(parser.parseCommand("eDit HelP"), expected);
     }
 
     @Test
     public void parseCommand_filter_help() throws Exception {
         assertTrue(parser.parseCommand("filter help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("filter help".toUpperCase()) instanceof HelpCommand);
+        assertTrue(parser.parseCommand("fIlTeR hElP") instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("filter");
         assertEquals(parser.parseCommand("filter help"), expected);
+        assertEquals(parser.parseCommand("filter help".toUpperCase()), expected);
+        assertEquals(parser.parseCommand("filTer hElP"), expected);
+
     }
 
     @Test
     public void parseCommand_list_help() throws Exception {
         assertTrue(parser.parseCommand("list help") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("list help".toUpperCase()) instanceof HelpCommand);
+        assertTrue(parser.parseCommand("liSt hElP") instanceof HelpCommand);
         HelpCommand expected = new HelpCommand("list");
         assertEquals(parser.parseCommand("list help"), expected);
+        assertEquals(parser.parseCommand("list help".toUpperCase()), expected);
+        assertEquals(parser.parseCommand("liSt hELP"), expected);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD.toUpperCase()) instanceof ListCommand);
+        assertTrue(parser.parseCommand("lIsT") instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD.toUpperCase() + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand("lIsT" + " 3") instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+                -> parser.parseCommand(""));
     }
 
     @Test


### PR DESCRIPTION
Fix #207 

## Changes:
- RealodexParser is now case sensitive
- Default command words are now lower cased. (`clearRealodex` -> `clearrealodex`)

## Testing
- RealodexParser tests added to comply with at least once strategy. This should be sufficient and tests for individual commands would likely be overkill based on the at least once strategy