### PR TITLE
V1.3 feature flaw `EditCommandParser` should return stacked edit error messages, refactor `AddCommandParser`, add more tests

### DIFF
--- a/src/main/java/seedu/realodex/logic/Messages.java
+++ b/src/main/java/seedu/realodex/logic/Messages.java
@@ -56,6 +56,7 @@ public class Messages {
                 .append(person.getFamily())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
+        builder.append("; Housing type: ").append(person.getHousingType());
         builder.append("; Remark: ")
                 .append(person.getRemark());
         builder.append("; Birthday: ").append(person.getBirthday());

--- a/src/main/java/seedu/realodex/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/realodex/logic/commands/AddCommand.java
@@ -26,7 +26,7 @@ public class AddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a client to the Realodex. "
-            + "Parameters: "
+            + "\nParameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_INCOME + "INCOME "
@@ -35,7 +35,7 @@ public class AddCommand extends Command {
             + PREFIX_FAMILY + "FAMILY "
             + PREFIX_TAG + "BUYER/SELLER "
             + PREFIX_HOUSINGTYPE + "HOUSING_TYPE "
-            + "[" + PREFIX_REMARK + "REMARK]\n"
+            + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
@@ -31,6 +31,8 @@ import seedu.realodex.model.person.Phone;
 import seedu.realodex.model.person.Remark;
 import seedu.realodex.model.tag.Tag;
 
+
+//@@author UdhayaShan1
 /**
  * Parses input arguments and creates a new AddCommand object
  */
@@ -192,3 +194,4 @@ public class AddCommandParser implements Parser<AddCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }
+//@@author

--- a/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
@@ -11,7 +11,9 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import seedu.realodex.logic.Messages;
@@ -37,105 +39,155 @@ public class AddCommandParser implements Parser<AddCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     *
+     * @param args The arguments provided by the user.
+     * @return The parsed AddCommand object.
+     * @throws ParseException If the user input does not conform to the expected format.
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_INCOME, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_FAMILY, PREFIX_TAG, PREFIX_HOUSINGTYPE, PREFIX_REMARK, PREFIX_BIRTHDAY);
+        ArgumentMultimap argMultimap = tokenizeArguments(args);
 
-        Prefix[] listOfCompulsoryPrefixTags = argMultimap.returnListOfCompulsoryTags(PREFIX_NAME, PREFIX_ADDRESS,
-                                                                                     PREFIX_INCOME, PREFIX_PHONE,
-                                                                                     PREFIX_FAMILY, PREFIX_EMAIL,
-                                                                                     PREFIX_TAG, PREFIX_HOUSINGTYPE);
-        if (!arePrefixesPresent(argMultimap,
-                                listOfCompulsoryPrefixTags)) {
-            String exceptionMessageForMissingPrefixes =
-                    argMultimap.returnMessageOfMissingPrefixes(listOfCompulsoryPrefixTags) + "\n";
-            throw new ParseException(Messages.getErrorMessageForMissingPrefixes(exceptionMessageForMissingPrefixes)
+        validateCompulsoryPrefixes(argMultimap);
+
+        validateNoDuplicatePrefixes(argMultimap);
+
+        Person person = buildPerson(argMultimap);
+
+        return new AddCommand(person);
+    }
+
+    /**
+     * Tokenizes the input arguments.
+     *
+     * @param args The arguments provided by the user.
+     * @return An ArgumentMultimap containing the parsed arguments.
+     */
+    private ArgumentMultimap tokenizeArguments(String args) {
+        return ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_INCOME, PREFIX_EMAIL, PREFIX_ADDRESS,
+                                          PREFIX_FAMILY, PREFIX_TAG, PREFIX_HOUSINGTYPE,
+                                          PREFIX_REMARK, PREFIX_BIRTHDAY);
+    }
+
+    /**
+     * Validates the presence of compulsory prefixes.
+     *
+     * @param argMultimap An ArgumentMultimap containing the parsed arguments.
+     * @throws ParseException If any compulsory prefix is missing.
+     */
+    private void validateCompulsoryPrefixes(ArgumentMultimap argMultimap) throws ParseException {
+        Prefix[] compulsoryPrefixes = {PREFIX_NAME, PREFIX_ADDRESS, PREFIX_INCOME, PREFIX_PHONE,
+            PREFIX_FAMILY, PREFIX_EMAIL,
+            PREFIX_TAG, PREFIX_HOUSINGTYPE};
+        if (!arePrefixesPresent(argMultimap, compulsoryPrefixes)) {
+            String missingPrefixesMessage = argMultimap.returnMessageOfMissingPrefixes(compulsoryPrefixes) + "\n";
+            throw new ParseException(Messages.getErrorMessageForMissingPrefixes(missingPrefixesMessage)
                                              + AddCommand.MESSAGE_USAGE);
         }
+    }
 
+    /**
+     * Validates the absence of duplicate prefixes.
+     *
+     * @param argMultimap An ArgumentMultimap containing the parsed arguments.
+     * @throws ParseException If any duplicate prefix is found.
+     */
+    private void validateNoDuplicatePrefixes(ArgumentMultimap argMultimap) throws ParseException {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_INCOME, PREFIX_EMAIL, PREFIX_FAMILY,
-                PREFIX_ADDRESS, PREFIX_HOUSINGTYPE, PREFIX_REMARK, PREFIX_BIRTHDAY);
+                                                 PREFIX_ADDRESS, PREFIX_HOUSINGTYPE, PREFIX_REMARK, PREFIX_BIRTHDAY);
+    }
 
+    /**
+     * Builds a Person object from the parsed arguments.
+     *
+     * @param argMultimap An ArgumentMultimap containing the parsed arguments.
+     * @return The constructed Person object.
+     * @throws ParseException If any error occurs during parsing.
+     */
+    private Person buildPerson(ArgumentMultimap argMultimap) throws ParseException {
         StringBuilder errorMessageBuilder = new StringBuilder();
-        ParserUtilResult<Name> nameStored =
-                ParserUtil.parseNameReturnStored(argMultimap.getValue(PREFIX_NAME).orElseThrow());
-        nameStored.buildErrorMessage(errorMessageBuilder, "name");
 
-        ParserUtilResult<Phone> phoneStored = ParserUtil.parsePhoneReturnStored(argMultimap.getValue(PREFIX_PHONE)
-                                                                                    .orElseThrow());
-
-        phoneStored.buildErrorMessage(errorMessageBuilder, "phone");
-
-        ParserUtilResult<Income> incomeStored =
-                ParserUtil.parseIncomeReturnStored(argMultimap.getValue(PREFIX_INCOME).orElseThrow());
-
-        incomeStored.buildErrorMessage(errorMessageBuilder, "income");
-
-        ParserUtilResult<Email> emailStored =
-                ParserUtil.parseEmailReturnStored(argMultimap.getValue(PREFIX_EMAIL).orElseThrow());
-
-        emailStored.buildErrorMessage(errorMessageBuilder, "email");
-
-        ParserUtilResult<Address> addressStored =
-                ParserUtil.parseAddressReturnStored(argMultimap.getValue(PREFIX_ADDRESS).orElseThrow());
-        addressStored.buildErrorMessage(errorMessageBuilder, "address");
-
-        ParserUtilResult<Family> familyStored =
-                ParserUtil.parseFamilyReturnStored(argMultimap.getValue(PREFIX_FAMILY).orElseThrow());
-        familyStored.buildErrorMessage(errorMessageBuilder, "family");
-
-        Set<Tag> tagList = null;
-        try {
-            tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        } catch (ParseException e) {
-            errorMessageBuilder.append("Error parsing tags: ").append(e.getMessage()).append("\n");
-        }
-
-        ParserUtilResult<HousingType> housingTypeStored =
-                ParserUtil.parseHousingTypeReturnStored(argMultimap
-                        .getValueOrDefault(PREFIX_HOUSINGTYPE).orElseThrow());
-        housingTypeStored.buildErrorMessage(errorMessageBuilder, "housing type");
-
-        Remark remark;
-
-        remark = ParserUtil.parseRemark(argMultimap.getValueOrDefault(PREFIX_REMARK).orElseThrow());
-
+        Name name = parseName(argMultimap, errorMessageBuilder);
+        Phone phone = parsePhone(argMultimap, errorMessageBuilder);
+        Income income = parseIncome(argMultimap, errorMessageBuilder);
+        Email email = parseEmail(argMultimap, errorMessageBuilder);
+        Address address = parseAddress(argMultimap, errorMessageBuilder);
+        Family family = parseFamily(argMultimap, errorMessageBuilder);
+        Set<Tag> tags = parseTags(argMultimap, errorMessageBuilder);
+        HousingType housingType = parseHousingType(argMultimap, errorMessageBuilder);
+        Remark remark = parseRemark(argMultimap, errorMessageBuilder);
         ParserUtilResult<Birthday> birthdayStored = ParserUtil
                 .parseBirthdayReturnStored(argMultimap
                                                    .getValueOrDefault(PREFIX_BIRTHDAY)
                                                    .orElseThrow());
         birthdayStored.buildErrorMessage(errorMessageBuilder, "birthday");
 
-
-        // If any parsing operation fails, throw a ParseException with the accumulated error messages
         if (errorMessageBuilder.length() > 0) {
             throw new ParseException(errorMessageBuilder.toString().trim());
         }
-
-        // If all parsing operations succeed, create the person object
-        Name name = nameStored.returnStoredResult();
-        Phone phone = phoneStored.returnStoredResult();
-        Income income = incomeStored.returnStoredResult();
-        Email email = emailStored.returnStoredResult();
-        Address address = addressStored.returnStoredResult();
-        Family family = familyStored.returnStoredResult();
-        HousingType housingType = housingTypeStored.returnStoredResult();
         Birthday birthday = birthdayStored.returnStoredResult();
-        Person person = new Person(name, phone, income, email, address, family, tagList, housingType, remark, birthday);
-        return new AddCommand(person);
+
+        return new Person(name, phone, income, email, address, family, tags, housingType, remark, birthday);
     }
 
-    /**
-     * Checks if all specified prefixes are present in the given ArgumentMultimap.
-     *
-     * @param argumentMultimap the ArgumentMultimap to check
-     * @param prefixes         the array of prefixes to check for
-     * @return {@code true} if all specified prefixes are present in the ArgumentMultimap,
-     *         {@code false} otherwise
-     */
+    // Methods for parsing individual fields
+    private Name parseName(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return parseField(argMultimap, PREFIX_NAME, errorMessageBuilder, ParserUtil::parseNameReturnStored, "name");
+    }
+
+    private Phone parsePhone(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return parseField(argMultimap, PREFIX_PHONE, errorMessageBuilder, ParserUtil::parsePhoneReturnStored, "phone");
+    }
+
+    private Income parseIncome(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return parseField(argMultimap, PREFIX_INCOME, errorMessageBuilder,
+                          ParserUtil::parseIncomeReturnStored,
+                          "income");
+    }
+
+    private Email parseEmail(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return parseField(argMultimap, PREFIX_EMAIL, errorMessageBuilder,
+                          ParserUtil::parseEmailReturnStored, "email");
+    }
+
+    private Address parseAddress(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return parseField(argMultimap, PREFIX_ADDRESS, errorMessageBuilder,
+                          ParserUtil::parseAddressReturnStored, "address");
+    }
+
+    private Family parseFamily(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return parseField(argMultimap, PREFIX_FAMILY, errorMessageBuilder,
+                          ParserUtil::parseFamilyReturnStored, "family");
+    }
+
+    private Set<Tag> parseTags(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        Set<Tag> tags = null;
+        try {
+            tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        } catch (ParseException e) {
+            errorMessageBuilder.append("Error parsing tags: ").append(e.getMessage()).append("\n");
+        }
+        return tags;
+    }
+
+    private HousingType parseHousingType(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return parseField(argMultimap, PREFIX_HOUSINGTYPE, errorMessageBuilder,
+                          ParserUtil::parseHousingTypeReturnStored, "housing type");
+    }
+
+    private Remark parseRemark(ArgumentMultimap argMultimap, StringBuilder errorMessageBuilder) {
+        return ParserUtil.parseRemark(Objects.requireNonNull(argMultimap.getValueOrDefault(PREFIX_REMARK)
+                                                                     .orElse(null)));
+    }
+
+
+    // Generic method for parsing individual fields
+    private <T> T parseField(ArgumentMultimap argMultimap, Prefix prefix, StringBuilder errorMessageBuilder,
+                             Function<String, ParserUtilResult<T>> parserFunction, String fieldName) {
+        ParserUtilResult<T> result = parserFunction.apply(argMultimap.getValue(prefix).orElseThrow());
+        result.buildErrorMessage(errorMessageBuilder, fieldName);
+        return result.returnStoredResult();
+    }
+
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix[] prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }

--- a/src/main/java/seedu/realodex/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/realodex/logic/parser/ArgumentMultimap.java
@@ -3,6 +3,7 @@ package seedu.realodex.logic.parser;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,7 @@ import seedu.realodex.logic.parser.exceptions.ParseException;
  * can be inserted multiple times for the same prefix.
  */
 public class ArgumentMultimap {
+    private final Prefix[] prefixWithBlankOptional = new Prefix[] {PREFIX_REMARK};
 
     /** Prefixes mapped to their respective arguments**/
     private final Map<Prefix, List<String>> argMultimap = new HashMap<>();
@@ -42,7 +44,7 @@ public class ArgumentMultimap {
      */
     public Optional<String> getValue(Prefix prefix) {
         List<String> values = getAllValues(prefix);
-        if (prefix.equals(PREFIX_REMARK)) {
+        if (Arrays.asList(prefixWithBlankOptional).contains(prefix)) {
             return values.isEmpty() ? Optional.of("") : Optional.of(values.get(values.size() - 1));
         }
         return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -12,15 +12,29 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 import seedu.realodex.commons.core.index.Index;
 import seedu.realodex.logic.commands.EditCommand;
 import seedu.realodex.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.realodex.logic.parser.exceptions.ParseException;
-
+import seedu.realodex.model.person.Address;
+import seedu.realodex.model.person.Birthday;
+import seedu.realodex.model.person.Email;
+import seedu.realodex.model.person.Family;
+import seedu.realodex.model.person.Income;
+import seedu.realodex.model.person.Name;
+import seedu.realodex.model.person.Phone;
+import seedu.realodex.model.tag.Tag;
+//@@author UdhayaShan1
 /**
  * Parses input arguments and creates a new EditCommand object
  */
 public class EditCommandParser implements Parser<EditCommand> {
+
+    private static final String MESSAGE_ERROR_PARSING_TAGS = "Error parsing tags: " + Tag.MESSAGE_CONSTRAINTS;
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
@@ -29,54 +43,70 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_INCOME, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_FAMILY, PREFIX_TAG, PREFIX_REMARK, PREFIX_BIRTHDAY);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_INCOME,
+                                                                PREFIX_EMAIL, PREFIX_ADDRESS,
+                                   PREFIX_FAMILY, PREFIX_TAG, PREFIX_REMARK, PREFIX_BIRTHDAY);
 
-        Index index;
+        Index index = parseIndex(argMultimap.getPreamble());
 
+        EditPersonDescriptor editPersonDescriptor = parseEditPersonDescriptor(argMultimap);
+
+        return new EditCommand(index, editPersonDescriptor);
+    }
+
+    private Index parseIndex(String preamble) throws ParseException {
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            return ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
+    }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_INCOME, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_FAMILY, PREFIX_REMARK, PREFIX_BIRTHDAY);
 
+    private EditPersonDescriptor parseEditPersonDescriptor(ArgumentMultimap argMultimap) throws ParseException {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+        StringBuilder errorMessageBuilder = new StringBuilder();
 
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        parseAndSetField(argMultimap, PREFIX_NAME, editPersonDescriptor::setName, ParserUtil::parseNameReturnStored, errorMessageBuilder, "name");
+        parseAndSetField(argMultimap, PREFIX_PHONE, editPersonDescriptor::setPhone, ParserUtil::parsePhoneReturnStored, errorMessageBuilder, "phone");
+        parseAndSetField(argMultimap, PREFIX_INCOME, editPersonDescriptor::setIncome, ParserUtil::parseIncomeReturnStored, errorMessageBuilder, "income");
+        parseAndSetField(argMultimap, PREFIX_EMAIL, editPersonDescriptor::setEmail, ParserUtil::parseEmailReturnStored, errorMessageBuilder, "email");
+        parseAndSetField(argMultimap, PREFIX_ADDRESS, editPersonDescriptor::setAddress, ParserUtil::parseAddressReturnStored, errorMessageBuilder, "address");
+        parseAndSetField(argMultimap, PREFIX_FAMILY, editPersonDescriptor::setFamily, ParserUtil::parseFamilyReturnStored, errorMessageBuilder, "family");
+        parseAndSetField(argMultimap, PREFIX_BIRTHDAY, editPersonDescriptor::setBirthday, ParserUtil::parseBirthdayReturnStored, errorMessageBuilder, "birthday");
+
+        if (argMultimap.containsPrefix(PREFIX_TAG)) {
+            try {
+                Set<Tag> parsedTagsForEdit = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+                editPersonDescriptor.setTags(parsedTagsForEdit);
+            } catch (ParseException exception) {
+                errorMessageBuilder.append(MESSAGE_ERROR_PARSING_TAGS);
+            }
         }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_INCOME).isPresent()) {
-            editPersonDescriptor.setIncome(ParserUtil.parseIncome(argMultimap.getValue(PREFIX_INCOME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
-        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
-        }
-        if (argMultimap.getValue(PREFIX_FAMILY).isPresent()) {
-            editPersonDescriptor.setFamily(ParserUtil.parseFamily(argMultimap.getValue(PREFIX_FAMILY).get()));
-        }
-        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            editPersonDescriptor.setTags(ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG)));
-        }
+
         if (argMultimap.containsPrefix(PREFIX_REMARK)) {
             editPersonDescriptor.setRemark(ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()));
         }
-        if (argMultimap.containsPrefix(PREFIX_BIRTHDAY)) {
-            editPersonDescriptor.setBirthday(ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY).get()));
+
+        if (errorMessageBuilder.length() > 0) {
+            throw new ParseException(errorMessageBuilder.toString());
         }
+
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editPersonDescriptor);
+        return editPersonDescriptor;
+    }
+
+    private <T> void parseAndSetField(ArgumentMultimap argMultimap, Prefix prefix, Consumer<T> setter,
+                                      Function<String, ParserUtilResult<T>> parserFunction,
+                                      StringBuilder errorMessageBuilder, String fieldName) {
+        if (argMultimap.getValue(prefix).isPresent()) {
+            ParserUtilResult<T> result = parserFunction.apply(argMultimap.getValue(prefix).get());
+            result.buildErrorMessage(errorMessageBuilder, fieldName);
+            setter.accept(result.returnStoredResult());
+        }
     }
 }
+//@@author

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -35,7 +35,7 @@ import seedu.realodex.model.tag.Tag;
  */
 public class EditCommandParser implements Parser<EditCommand> {
 
-    private static final String MESSAGE_ERROR_PARSING_TAGS = "Error parsing tags: " + Tag.MESSAGE_CONSTRAINTS;
+    public static final String MESSAGE_ERROR_PARSING_TAGS = "Error parsing tags: " + Tag.MESSAGE_CONSTRAINTS;
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
@@ -78,7 +78,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseAndSetField(argMultimap, PREFIX_ADDRESS, editPersonDescriptor::setAddress, ParserUtil::parseAddressReturnStored, errorMessageBuilder, "address");
         parseAndSetField(argMultimap, PREFIX_FAMILY, editPersonDescriptor::setFamily, ParserUtil::parseFamilyReturnStored, errorMessageBuilder, "family");
         parseAndSetField(argMultimap, PREFIX_BIRTHDAY, editPersonDescriptor::setBirthday, ParserUtil::parseBirthdayReturnStored, errorMessageBuilder, "birthday");
-        parseAndSetField(argMultimap, PREFIX_HOUSINGTYPE, editPersonDescriptor::setHousingType, ParserUtil::parseHousingTypeReturnStored, errorMessageBuilder, "house type");
+        parseAndSetField(argMultimap, PREFIX_HOUSINGTYPE, editPersonDescriptor::setHousingType,
+                         ParserUtil::parseHousingTypeReturnStored, errorMessageBuilder, "housing type");
 
         //These fields do not have ParseUtilResult implementation
         if (argMultimap.containsPrefix(PREFIX_TAG)) {

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -13,7 +13,6 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -13,6 +13,7 @@ import static seedu.realodex.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.realodex.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -22,6 +22,7 @@ import seedu.realodex.logic.commands.EditCommand;
 import seedu.realodex.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.realodex.logic.parser.exceptions.ParseException;
 import seedu.realodex.model.tag.Tag;
+
 //@@author UdhayaShan1
 /**
  * Parses input arguments and creates a new EditCommand object

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -21,13 +21,6 @@ import seedu.realodex.commons.core.index.Index;
 import seedu.realodex.logic.commands.EditCommand;
 import seedu.realodex.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.realodex.logic.parser.exceptions.ParseException;
-import seedu.realodex.model.person.Address;
-import seedu.realodex.model.person.Birthday;
-import seedu.realodex.model.person.Email;
-import seedu.realodex.model.person.Family;
-import seedu.realodex.model.person.Income;
-import seedu.realodex.model.person.Name;
-import seedu.realodex.model.person.Phone;
 import seedu.realodex.model.tag.Tag;
 //@@author UdhayaShan1
 /**
@@ -71,13 +64,20 @@ public class EditCommandParser implements Parser<EditCommand> {
         StringBuilder errorMessageBuilder = new StringBuilder();
 
         //For fields with ParserUtilResult implementation
-        parseAndSetField(argMultimap, PREFIX_NAME, editPersonDescriptor::setName, ParserUtil::parseNameReturnStored, errorMessageBuilder, "name");
-        parseAndSetField(argMultimap, PREFIX_PHONE, editPersonDescriptor::setPhone, ParserUtil::parsePhoneReturnStored, errorMessageBuilder, "phone");
-        parseAndSetField(argMultimap, PREFIX_INCOME, editPersonDescriptor::setIncome, ParserUtil::parseIncomeReturnStored, errorMessageBuilder, "income");
-        parseAndSetField(argMultimap, PREFIX_EMAIL, editPersonDescriptor::setEmail, ParserUtil::parseEmailReturnStored, errorMessageBuilder, "email");
-        parseAndSetField(argMultimap, PREFIX_ADDRESS, editPersonDescriptor::setAddress, ParserUtil::parseAddressReturnStored, errorMessageBuilder, "address");
-        parseAndSetField(argMultimap, PREFIX_FAMILY, editPersonDescriptor::setFamily, ParserUtil::parseFamilyReturnStored, errorMessageBuilder, "family");
-        parseAndSetField(argMultimap, PREFIX_BIRTHDAY, editPersonDescriptor::setBirthday, ParserUtil::parseBirthdayReturnStored, errorMessageBuilder, "birthday");
+        parseAndSetField(argMultimap, PREFIX_NAME, editPersonDescriptor::setName,
+                         ParserUtil::parseNameReturnStored, errorMessageBuilder, "name");
+        parseAndSetField(argMultimap, PREFIX_PHONE, editPersonDescriptor::setPhone,
+                         ParserUtil::parsePhoneReturnStored, errorMessageBuilder, "phone");
+        parseAndSetField(argMultimap, PREFIX_INCOME, editPersonDescriptor::setIncome,
+                         ParserUtil::parseIncomeReturnStored, errorMessageBuilder, "income");
+        parseAndSetField(argMultimap, PREFIX_EMAIL, editPersonDescriptor::setEmail,
+                         ParserUtil::parseEmailReturnStored, errorMessageBuilder, "email");
+        parseAndSetField(argMultimap, PREFIX_ADDRESS, editPersonDescriptor::setAddress,
+                         ParserUtil::parseAddressReturnStored, errorMessageBuilder, "address");
+        parseAndSetField(argMultimap, PREFIX_FAMILY, editPersonDescriptor::setFamily,
+                         ParserUtil::parseFamilyReturnStored, errorMessageBuilder, "family");
+        parseAndSetField(argMultimap, PREFIX_BIRTHDAY, editPersonDescriptor::setBirthday,
+                         ParserUtil::parseBirthdayReturnStored, errorMessageBuilder, "birthday");
         parseAndSetField(argMultimap, PREFIX_HOUSINGTYPE, editPersonDescriptor::setHousingType,
                          ParserUtil::parseHousingTypeReturnStored, errorMessageBuilder, "housing type");
 

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -67,6 +67,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         StringBuilder errorMessageBuilder = new StringBuilder();
 
+        //For fields with ParserUtilResult implementation
         parseAndSetField(argMultimap, PREFIX_NAME, editPersonDescriptor::setName, ParserUtil::parseNameReturnStored, errorMessageBuilder, "name");
         parseAndSetField(argMultimap, PREFIX_PHONE, editPersonDescriptor::setPhone, ParserUtil::parsePhoneReturnStored, errorMessageBuilder, "phone");
         parseAndSetField(argMultimap, PREFIX_INCOME, editPersonDescriptor::setIncome, ParserUtil::parseIncomeReturnStored, errorMessageBuilder, "income");
@@ -75,6 +76,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseAndSetField(argMultimap, PREFIX_FAMILY, editPersonDescriptor::setFamily, ParserUtil::parseFamilyReturnStored, errorMessageBuilder, "family");
         parseAndSetField(argMultimap, PREFIX_BIRTHDAY, editPersonDescriptor::setBirthday, ParserUtil::parseBirthdayReturnStored, errorMessageBuilder, "birthday");
 
+        //These fields do not have ParseUtilResult implementation
         if (argMultimap.containsPrefix(PREFIX_TAG)) {
             try {
                 Set<Tag> parsedTagsForEdit = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));

--- a/src/test/java/seedu/realodex/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/realodex/logic/commands/EditCommandTest.java
@@ -5,9 +5,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.realodex.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_BIRTHDAY_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_FAMILY_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_HOUSINGTYPE_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_HOUSINGTYPE_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_AMY_FIRST_LETTER_CAPS;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_AMY_VARYING_CAPS;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_NAME_BOB_FIRST_LETTER_CAPS;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
 import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_AMY;
+import static seedu.realodex.logic.commands.CommandTestUtil.VALID_TAG_BOB;
 import static seedu.realodex.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.realodex.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.realodex.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -34,6 +45,7 @@ import seedu.realodex.testutil.PersonBuilder;
 public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalRealodex(), new UserPrefs());
+
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -147,6 +159,172 @@ public class EditCommandTest {
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
+
+    @Test
+    public void execute_editName_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withName(VALID_NAME_AMY_FIRST_LETTER_CAPS).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY_FIRST_LETTER_CAPS).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editPhone_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withPhone(VALID_PHONE_AMY).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editAddress_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withAddress(VALID_ADDRESS_AMY).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editEmail_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withEmail(VALID_EMAIL_AMY).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editFamily_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        //edit from 4 to 5
+        Person editedPerson = personInList.withFamily("5").build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withFamily("5").build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editTags_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        //edit from buyer to seller
+        Person editedPerson = personInList.withTags(VALID_TAG_BOB).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withTags(VALID_TAG_BOB).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editHousingType_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        //edit from hdb to condo
+        Person editedPerson = personInList.withHousingType(VALID_HOUSINGTYPE_BOB).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withHousingType(VALID_HOUSINGTYPE_BOB).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editRemark_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withRemark(VALID_REMARK_AMY).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withRemark(VALID_REMARK_AMY).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editBirthday_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withBirthday(VALID_BIRTHDAY_AMY).build();
+        EditPersonDescriptor descriptor =
+                new EditPersonDescriptorBuilder().withBirthday(VALID_BIRTHDAY_AMY).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/realodex/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/realodex/logic/commands/EditCommandTest.java
@@ -252,6 +252,46 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_editMultipleFields_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        // Edit multiple fields at once
+        Person editedPerson = personInList.withName(VALID_NAME_AMY_VARYING_CAPS)
+                .withPhone(VALID_PHONE_AMY)
+                .withAddress(VALID_ADDRESS_AMY)
+                .withEmail(VALID_EMAIL_AMY)
+                .withFamily(VALID_FAMILY_AMY)
+                .withTags(VALID_TAG_AMY)
+                .withHousingType(VALID_HOUSINGTYPE_AMY)
+                .withRemark(VALID_REMARK_AMY)
+                .withBirthday(VALID_BIRTHDAY_AMY)
+                .build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withName(VALID_NAME_AMY_VARYING_CAPS)
+                .withPhone(VALID_PHONE_AMY)
+                .withAddress(VALID_ADDRESS_AMY)
+                .withEmail(VALID_EMAIL_AMY)
+                .withFamily(VALID_FAMILY_AMY)
+                .withTags(VALID_TAG_AMY)
+                .withHousingType(VALID_HOUSINGTYPE_AMY)
+                .withRemark(VALID_REMARK_AMY)
+                .withBirthday(VALID_BIRTHDAY_AMY)
+                .build();
+
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        Model expectedModel = new ModelManager(new Realodex(model.getRealodex()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
     public void execute_editTags_success() {
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());

--- a/src/test/java/seedu/realodex/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/realodex/logic/commands/SortCommandTest.java
@@ -2,6 +2,7 @@ package seedu.realodex.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.realodex.testutil.TypicalPersons.getSecondTypicalRealodex;
 import static seedu.realodex.testutil.TypicalPersons.getTypicalRealodex;
 
 import java.util.List;
@@ -19,6 +20,7 @@ import seedu.realodex.model.person.sorting.BirthdayComparator;
 
 public class SortCommandTest {
     private final Model model = new ModelManager(getTypicalRealodex(), new UserPrefs());
+    private final Model modelSecond = new ModelManager(getSecondTypicalRealodex(), new UserPrefs());
     @Test
     public void execute_sortsListByBirthday_success() {
         // Create a list of persons with birthdays in random order
@@ -35,6 +37,16 @@ public class SortCommandTest {
         // Verify that the list is sorted by birthday
         List<Person> sortedList = realodex.getCopyOfInternalListOfUniquePersonsList();
         assertTrue(isSortedByBirthday(sortedList));
+
+        realodex = (Realodex) modelSecond.getRealodex();
+        try {
+            sortCommand.execute(modelSecond);
+        } catch (CommandException e) {
+            Assertions.fail();
+        }
+        sortedList = realodex.getCopyOfInternalListOfUniquePersonsList();
+        assertTrue(isSortedByBirthday(sortedList));
+
     }
 
     @Test

--- a/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
@@ -106,7 +106,9 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        String errorMessage = "Error parsing %s: ";
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC,
+                           String.format(errorMessage, "name") + Name.MESSAGE_CONSTRAINTS + "\n"); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_INCOME_DESC, Income.MESSAGE_CONSTRAINTS); // invalid income
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
@@ -313,6 +315,7 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
 
-        assertParseFailure(parser, userInput, String.format(Tag.MESSAGE_CONSTRAINTS, targetIndex.getOneBased()));
+        assertParseFailure(parser, userInput, String.format("Error parsing tags: " + Tag.MESSAGE_CONSTRAINTS,
+                                                            targetIndex.getOneBased()));
     }
 }

--- a/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
@@ -115,32 +115,73 @@ public class EditCommandParserTest {
         String errorMessage = "Error parsing %s: ";
         assertParseFailure(parser, "1" + INVALID_NAME_DESC,
                            String.format(errorMessage, "name") + Name.MESSAGE_CONSTRAINTS + "\n"); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_INCOME_DESC, Income.MESSAGE_CONSTRAINTS); // invalid income
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, "1" + INVALID_FAMILY_DESC, Family.MESSAGE_CONSTRAINTS); // invalid family
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
-        assertParseFailure(parser, "1" + INVALID_HOUSINGTYPE_DESC, HousingType.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC,
+                           String.format(errorMessage, "phone") + Phone.MESSAGE_CONSTRAINTS + "\n"); // invalid phone
+        assertParseFailure(parser, "1" + INVALID_INCOME_DESC,
+                           String.format(errorMessage, "income") + Income.MESSAGE_CONSTRAINTS + "\n"); // invalid income
+        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC,
+                           String.format(errorMessage, "email") + Email.MESSAGE_CONSTRAINTS + "\n"); // invalid email
+        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC,
+                           String.format(errorMessage, "address") + Address.MESSAGE_CONSTRAINTS + "\n"); // invalid address
+        assertParseFailure(parser, "1" + INVALID_FAMILY_DESC,
+                           String.format(errorMessage, "family") + Family.MESSAGE_CONSTRAINTS + "\n"); // invalid family
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, EditCommandParser.MESSAGE_ERROR_PARSING_TAGS); // invalid tag
         // invalid housing type
-        assertParseFailure(parser, "1" + INVALID_BIRTHDAY_DESC, Birthday.MESSAGE_CONSTRAINTS); // invalid bday
+        assertParseFailure(parser, "1" + INVALID_HOUSINGTYPE_DESC,
+                           String.format(errorMessage, "housing type") + HousingType.MESSAGE_CONSTRAINTS + "\n");
+        //invalid birthday
+        assertParseFailure(parser, "1" + INVALID_BIRTHDAY_DESC,
+                           String.format(errorMessage, "birthday") + Birthday.MESSAGE_CONSTRAINTS + "\n"); // invalid bday
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY,
+                           String.format(errorMessage, "phone") + Phone.MESSAGE_CONSTRAINTS + "\n");
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
         assertParseFailure(parser, "1" + TAG_DESC_BOB
-                + CommandTestUtil.TAG_DESC_BOB + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_BOB + TAG_EMPTY, EditCommandParser.MESSAGE_ERROR_PARSING_TAGS);
         assertParseFailure(parser, "1" + TAG_DESC_BOB + TAG_EMPTY
-                + CommandTestUtil.TAG_DESC_BOB, Tag.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_BOB, EditCommandParser.MESSAGE_ERROR_PARSING_TAGS);
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_BOB
-                + CommandTestUtil.TAG_DESC_BOB, Tag.MESSAGE_CONSTRAINTS);
-
-        // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY
-                        + VALID_PHONE_AMY, Name.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_BOB, EditCommandParser.MESSAGE_ERROR_PARSING_TAGS);
     }
+
+    @Test
+    public void parse_invalidMultipleValues_failure() {
+        String errorMessage = "Error parsing %s: ";
+
+        // Test case 1: Invalid name, phone, and email
+        String userInput1 = "1" + INVALID_NAME_DESC + INVALID_PHONE_DESC
+                + INVALID_EMAIL_DESC;
+
+        String expectedErrorMessage1 = String.format(errorMessage, "name") + Name.MESSAGE_CONSTRAINTS + "\n"
+                + String.format(errorMessage, "phone") + Phone.MESSAGE_CONSTRAINTS + "\n"
+                + String.format(errorMessage, "email") + Email.MESSAGE_CONSTRAINTS + "\n";
+
+        assertParseFailure(parser, userInput1, expectedErrorMessage1);
+
+        // Test case 2: Invalid phone, income, and tag
+        String userInput2 = "1" + INVALID_PHONE_DESC + INVALID_INCOME_DESC
+                + INVALID_TAG_DESC;
+
+        String expectedErrorMessage2 = String.format(errorMessage, "phone") + Phone.MESSAGE_CONSTRAINTS + "\n"
+                + String.format(errorMessage, "income") + Income.MESSAGE_CONSTRAINTS + "\n"
+                + EditCommandParser.MESSAGE_ERROR_PARSING_TAGS;
+
+        assertParseFailure(parser, userInput2, expectedErrorMessage2);
+
+        // Test case 3: Invalid email, address, and family
+        String userInput3 = "1" + INVALID_EMAIL_DESC + INVALID_ADDRESS_DESC
+                + INVALID_FAMILY_DESC;
+
+        String expectedErrorMessage3 = String.format(errorMessage, "email") + Email.MESSAGE_CONSTRAINTS + "\n"
+                + String.format(errorMessage, "address") + Address.MESSAGE_CONSTRAINTS + "\n"
+                + String.format(errorMessage, "family") + Family.MESSAGE_CONSTRAINTS + "\n";
+
+        assertParseFailure(parser, userInput3, expectedErrorMessage3);
+    }
+
 
     @Test
     public void parse_allFieldsSpecified_success() {

--- a/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/realodex/logic/parser/EditCommandParserTest.java
@@ -122,16 +122,19 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC,
                            String.format(errorMessage, "email") + Email.MESSAGE_CONSTRAINTS + "\n"); // invalid email
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC,
-                           String.format(errorMessage, "address") + Address.MESSAGE_CONSTRAINTS + "\n"); // invalid address
+                           String.format(errorMessage, "address")
+                                   + Address.MESSAGE_CONSTRAINTS + "\n"); // invalid address
         assertParseFailure(parser, "1" + INVALID_FAMILY_DESC,
                            String.format(errorMessage, "family") + Family.MESSAGE_CONSTRAINTS + "\n"); // invalid family
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, EditCommandParser.MESSAGE_ERROR_PARSING_TAGS); // invalid tag
         // invalid housing type
         assertParseFailure(parser, "1" + INVALID_HOUSINGTYPE_DESC,
-                           String.format(errorMessage, "housing type") + HousingType.MESSAGE_CONSTRAINTS + "\n");
+                           String.format(errorMessage, "housing type")
+                                   + HousingType.MESSAGE_CONSTRAINTS + "\n");
         //invalid birthday
         assertParseFailure(parser, "1" + INVALID_BIRTHDAY_DESC,
-                           String.format(errorMessage, "birthday") + Birthday.MESSAGE_CONSTRAINTS + "\n"); // invalid bday
+                           String.format(errorMessage, "birthday")
+                                   + Birthday.MESSAGE_CONSTRAINTS + "\n"); // invalid bday
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY,

--- a/src/test/java/seedu/realodex/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/realodex/model/person/BirthdayTest.java
@@ -56,6 +56,7 @@ public class BirthdayTest {
         assertTrue(Birthday.isValidBirthday("29Feb2024")); // leap year
         assertTrue(Birthday.isValidBirthday("12May2003"));
         assertTrue(Birthday.isValidBirthday("08Aug1888"));
+        assertTrue(Birthday.isValidBirthday("08Aug888")); //before year 1000
 
         // invalid dates
         assertFalse(Birthday.isValidBirthday("01May2009233"));

--- a/src/test/java/seedu/realodex/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/realodex/model/person/BirthdayTest.java
@@ -56,7 +56,6 @@ public class BirthdayTest {
         assertTrue(Birthday.isValidBirthday("29Feb2024")); // leap year
         assertTrue(Birthday.isValidBirthday("12May2003"));
         assertTrue(Birthday.isValidBirthday("08Aug1888"));
-        assertTrue(Birthday.isValidBirthday("08Aug888")); //before year 1000
 
         // invalid dates
         assertFalse(Birthday.isValidBirthday("01May2009233"));

--- a/src/test/java/seedu/realodex/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/realodex/testutil/TypicalPersons.java
@@ -87,6 +87,42 @@ public class TypicalPersons {
             .withEmail("hans@example.com").withAddress("chicago ave")
             .withTags("buyer").withHousingType("HDB").withBirthday("23Apr1983").build();
 
+    public static final Person HENRY = new PersonBuilder().withName("Henry Johnson").withPhone("9482541")
+            .withIncome("80000").withEmail("john@example.com").withAddress("5th avenue").withTags("seller")
+            .withHousingType("HDB").withBirthday("12Mar1995").build();
+
+    public static final Person ISABELLA = new PersonBuilder().withName("Isabella Lee").withPhone("9482682")
+            .withIncome("90000").withEmail("isabella@example.com").withAddress("main street").withTags("buyer")
+            .withHousingType("HDB").withBirthday("5Sep1990").build();
+
+    public static final Person JACKSON = new PersonBuilder().withName("Jackson Wang").withPhone("9482335")
+            .withIncome("100000").withEmail("jackson@example.com").withAddress("baker street").withTags("seller")
+            .withHousingType("HDB").withBirthday("8Jul1988").build();
+
+    public static final Person KATHERINE = new PersonBuilder().withName("Katherine Smith").withPhone("9482774")
+            .withIncome("110000").withEmail("katherine@example.com").withAddress("park avenue").withTags("buyer")
+            .withHousingType("HDB").withBirthday("16Nov1984").build();
+
+    public static final Person LUCAS = new PersonBuilder().withName("Lucas Brown").withPhone("9482993")
+            .withIncome("120000").withEmail("lucas@example.com").withAddress("ocean drive").withTags("seller")
+            .withHousingType("HDB").withBirthday("20Jan1980").build();
+
+    public static final Person MADELINE = new PersonBuilder().withName("Madeline Garcia").withPhone("9482662")
+            .withIncome("130000").withEmail("madeline@example.com").withAddress("wallace street").withTags("buyer")
+            .withHousingType("HDB").withBirthday("9Apr1976").build();
+
+    public static final Person NATHANIEL = new PersonBuilder().withName("Nathaniel Martinez").withPhone("9482891")
+            .withIncome("140000").withEmail("nathaniel@example.com").withAddress("elm street").withTags("seller")
+            .withHousingType("HDB").withBirthday("14Aug1972").build();
+
+    public static final Person OLIVIA = new PersonBuilder().withName("Olivia Taylor").withPhone("9482889")
+            .withIncome("150000").withEmail("olivia@example.com").withAddress("maple street").withTags("buyer")
+            .withHousingType("HDB").withBirthday("17Dec1968").build();
+
+
+
+
+
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY_NAME_CAPS = new PersonBuilder().withName(VALID_NAME_AMY_FIRST_LETTER_CAPS)
             .withPhone(VALID_PHONE_AMY)
@@ -118,13 +154,28 @@ public class TypicalPersons {
      */
     public static Realodex getTypicalRealodex() {
         Realodex ab = new Realodex();
-        for (Person person : getTypicalPersons()) {
+        for (Person person : getFirstTypicalPersons()) {
             ab.addPerson(person);
         }
         return ab;
     }
 
-    public static List<Person> getTypicalPersons() {
+    /**
+     * Returns an {@code Realodex} with another typical persons list.
+     */
+    public static Realodex getSecondTypicalRealodex() {
+        Realodex ab = new Realodex();
+        for (Person person : getSecondTypicalPersons()) {
+            ab.addPerson(person);
+        }
+        return ab;
+    }
+
+    public static List<Person> getFirstTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
+    public static List<Person> getSecondTypicalPersons() {
+        return new ArrayList<>(Arrays.asList(HENRY, ISABELLA, JACKSON , KATHERINE, LUCAS, MADELINE , NATHANIEL));
     }
 }


### PR DESCRIPTION
`EditCommandParser` will now return stacked error messages to make it clearer to users which input went wrong.

Refactor `EditCommandParser` and `AddCommandParser` to adhere to better code quality standards.

Add comprehensive testing for `EditCommand`.