### PR TITLE
Changes to UG and DG to address PE-D feedback

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -387,6 +387,9 @@ The core components for this feature are:
   prints the help message in the Main Window for the requested command, depending on user input.
 - HelpCommandParser: Processes the user input to instantiate the HelpCommand object appropriately to perform the
   correct action (the type of help to give, in this case for individual commands).
+- Note that although the command format is `COMMAND help`, `clear help` is the command to get the help for the clearRealodex command instead of `clearRealodex help`.
+We changed the `clear` command to `clearRealodex` to avoid confusion with the `delete` command, as both involve the removal of entries, and `clearRealodex`
+encapsulates the functionality of clearing the entire app more clearly. However, we kept `clear help` as this syntax is more user-friendly when seeking help.
 
 #### Example Usage Scenario 
 1. User launches the application.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -96,7 +96,7 @@ Adds a client to Realodex.
     <a href="parsing_errors.png">
     <img src="parsing_errors.png" alt="duplicate person" style="width:150%">
     </a>
-- You may have duplicate persons with the same name in Realodex.
+- You **cannot** have duplicate persons with the same name in Realodex.
   - Names are case-insensitive as described in [Field Constraints](#field-constraints).
   - If you try to add duplicate persons, you will get the error message "This client already exists in Realodex".
     <a href="images/add-command/duplicate_person_error.png">
@@ -317,12 +317,15 @@ Shows the help message for the specified command only.
 
 <u>Format:</u> `COMMAND help`
 
+- Note that this feature is only available for the `add`,`clearRealodex`,`delete`,`edit`,`filter`,`list` and `sort` commands.
+- Although the format is `COMMAND help`, the exception is the help message for the clear command. Use `clear help` instead of `clearRealodex help`.
+
 <u>Examples:</u>
 <p align="center">
       <a href="images/help/clear_help.png">
       <img src="images/help/clear_help.png" alt="filterByTagSeller" style="width:100%">
       </a>
-  <em> <code>clear help</code> provides the help message for the clear command</em>
+  <em> <code>clear help</code> provides the help message for the clearRealodex command</em>
 </p>
 
 
@@ -356,7 +359,7 @@ Furthermore, certain edits can cause the Realodex to behave in unexpected ways (
 
 #### Restarting with New Data
 Should you want to re-enter your contacts in a fresh JSON file in the event of file corruption or a bad edit causing the format to be incorrect,
-simply delete `realodex.json` and restart the app. A new JSON file with sample contacts will be generated and you may proceed from there.
+simply delete `realodex.json`, which can be found in the `data` folder, and restart the app. A new JSON file with sample contacts will be generated and you may proceed from there.
 
 --------------------------------------------------------------------------------------------------------------------
 ## Field Constraints


### PR DESCRIPTION
# This PR fixes issues #245 , #248 , #261 , #271 , #273 

- Fix a small typo in add command details in UG (cannot have duplicate names) - #245 
- Add information regarding the inconsistency for the `clearRealodex` command - #248 # #271 
- Add information in DG justifying our design choice for `clear help` over `clearRealodex help` - #261 
- Add information in DG justifying `clearRealodex` over `clear` - #273 