### PR TITLE
Fix `FAMILY` check, fix `EMAIL` regex, add UG edits

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -332,12 +332,13 @@ This is an intentional design choice to ensure that the command is used for targ
 - Month input should be a valid month in `MMM` format and non-empty.
   - Filtering by month "September" should be `filter b/Sep`
     - `filter b/SEP` matches person with Birthday in September.
-- Month input will also accept extraneous input,
-  as long as it is not the same birthday prefix with spaces before, <br>`e.g. filter b/Sep b/mog`,
-  as that will be considered as duplicate prefixes.
-  If the first few characters are any valid month, it will be valid. 
+- Month input will also accept extraneous input, i.e. if the first 3 characters are any valid month, it will be valid.
   E.g.,
   This forgiving behavior allows you to type in `filter b/AprMogger` and Realodex will interpret the month as April!
+
+  ⚠️ This does not apply
+  if the extraneous input is the **same birthday prefix with spaces before** it,
+  `e.g. filter b/Sep b/mog` as that will be considered as **duplicate birthday prefixes.**
 - **Comprehensive searching**, returning all persons with birthdays in the specified month.
     - `filter b/Jan` returns all persons with birthday in January.
 - Persons who do not have a specified birthday will **not be included** in the search results.
@@ -353,6 +354,7 @@ This is an intentional design choice to ensure that the command is used for targ
 </p>
 
 --------------------------------------------------------------------------------------------------------------------
+<div style="page-break-after: always;"></div>
 
 ### Listing clients : `list`
 
@@ -360,6 +362,7 @@ Lists all clients in Realodex.
 
 <u>Format:</u> `list`
 
+--------------------------------------------------------------------------------------------------------------------
 
 ### Sort : `sort`
 
@@ -383,6 +386,8 @@ Clears all clients in Realodex.
 
 <u>Format:</u> `clearRealodex`
 
+--------------------------------------------------------------------------------------------------------------------
+
 ### Help : `help`
 
 Generates a pop-up window which is a summarised version of the User Guide. This window can also be accessed by the "Help" button on the top menu.
@@ -397,6 +402,8 @@ Shows the help message for the specified command only.
 
 - Note that this feature is only available for the `add`,`clearRealodex`,`delete`,`edit`,`filter`,`list` and `sort` commands.
 - Although the format is `COMMAND help`, the exception is the help message for the clear command. Use `clear help` instead of `clearRealodex help`.
+  <br>Exception also includes `help` command where `help help` will simply open up the window as expected
+      and `exit` command where `exit help` will simply exit the application as expected.
 
 <u>Examples:</u>
 <p align="center">
@@ -406,6 +413,7 @@ Shows the help message for the specified command only.
   <em> <code>clear help</code> provides the help message for the clearRealodex command</em>
 </p>
 
+--------------------------------------------------------------------------------------------------------------------
 
 ### Exiting the program : `exit`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -26,9 +26,9 @@ If you can type fast, Realodex can get your contact management tasks done faster
 1. Open a command terminal, `cd` into the folder you put the jar file in, and use the `java -jar realodex.jar`
 command to run the application.<br>
    A GUI similar to the below should appear in a few seconds. The app should contain some sample entries.<br>
-   <a href="images/Ui.png">
-   <img src="images/Ui.png" alt="Ui Image" style="width:50%">
-   </a>
+  <div style="display:flex; justify-content: center; align-items:center;">
+    <img src="images/Ui.png" alt="Ui" style=" width: 450px; margin-bottom: 16px;">
+  </div>
 
 1. Some example commands you can try:
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -313,7 +313,8 @@ This is an intentional design choice to ensure that the command is used for targ
   - Filtering by month "September" should be `filter b/Sep`
     - `filter b/SEP` matches person with Birthday in September.
 - Month input will also accept extraneous input,
-  as long as it is not the same prefix as that will be considered as duplicate prefixes.
+  as long as it is not the same birthday prefix with spaces before, <br>`e.g. filter b/Sep b/mog`,
+  as that will be considered as duplicate prefixes.
   If the first few characters are any valid month, it will be valid. 
   E.g.,
   This forgiving behavior allows you to type in `filter b/AprMogger` and Realodex will interpret the month as April!

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -311,6 +311,11 @@ This is an intentional design choice to ensure that the command is used for targ
 - Month input should be a valid month in `MMM` format and non-empty.
   - Filtering by month "September" should be `filter b/Sep`
     - `filter b/SEP` matches person with Birthday in September.
+- Month input will also accept extraneous input,
+  as long as it is not the same prefix as that will be considered as duplicate prefixes.
+  If the first few characters are any valid month, it will be valid. 
+  E.g.,
+  This forgiving behavior allows you to type in `filter b/AprMogger` and Realodex will interpret the month as April!
 - **Comprehensive searching**, returning all persons with birthdays in the specified month.
     - `filter b/Jan` returns all persons with birthday in January.
 - Persons who do not have a specified birthday will **not be included** in the search results.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -419,6 +419,14 @@ simply delete `realodex.json`, which can be found in the `data` folder, and rest
     * Example: `n/John Doe` and `n/john   doe` are both considered the same valid name but both will be displayed as `JOHN DOE`.
 * `PHONE`:
     * Should only contain numbers, and should be at least 3 digits long.
+    * While we disallow usage of symbols such as `+`, if you wish to use country codes, a reasonable 
+      work-around is to omit using of
+      symbols.
+      E.g., to input `+6590215365` you may simply type in `6590215635`
+    * Spaces are also not allowed.
+      However, a simple work-around for this is to omit using such spaces.
+      E.g.
+      to input `9021 5365` we can simply type in `90215365`.
     * Example: `p/81234567`
 * `INCOME`:
     * Income should be an integer and should be at least 0.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -190,7 +190,8 @@ Edits specified details of the client.
     and will no longer be interpreted as a non-zero unsigned integer.
     Hence, below error message applies.
 - If `INDEX` is a **non-zero unsigned integer**, error message will be shown "Invalid command format..."
-- 💡 If you currently have a filtered list present, the index will be based on the filtered list.
+- 💡 If you currently have a filtered list after `filter` operations, 
+      the index will be based on the filtered list.
 - It is optional to edit any field (i.e, you can choose to edit any combination of fields so long there is **at least 1**).
 - The current information will be overwritten with the input provided.
 - When editing the `TAG`, all existing tags will be overwritten with the new tag(s) provided. If you want to edit the client to be both a buyer and seller, include both tags i.e. `t/Buyer t/Seller`.
@@ -346,6 +347,7 @@ calculated by the number of days until their next birthday relative to the curre
 - The current date is based on the local system's time.
 - If their birthday has already passed, the calculation is based on the number of days until their next birthday next year.
 - If the list presented is currently a filtered list after using `filter`, sort will work on the new filtered list.
+- If a birthday falls on February 29th (leap day), the day calculation is based on March 1st if the year does not have a leap date.
 
 
 ### Clearing Realodex : `clearRealodex`
@@ -446,6 +448,8 @@ simply delete `realodex.json`, which can be found in the `data` folder, and rest
         * have each domain label start and end with alphanumeric characters
         * have each domain label consist of alphanumeric characters, separated only by hyphens, if any.
     * Example: `e/realodex-admin@gmail.com`
+    4. Top-level domain (TLD) such as `.com` are not compulsory, as according to 
+       [Internet Protocol Standards](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1)
 * `ADDRESS`: Current residential address
     * Must not include other command prefixes (`a/`,`b/`,`e/`,`f/`,`h/`,`i/`,`n/`,`p/`,`r/`,`t/`) to prevent parsing errors. For instance, `a/lemontree street t/1` may cause the command to fail, as the system will interpret `t/` as an unintended tag prefix.
     * Example: `a/6 College Ave West`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -455,7 +455,7 @@ simply delete `realodex.json`, which can be found in the `data` folder, and rest
     * Must not include other command prefixes (`a/`,`b/`,`e/`,`f/`,`h/`,`i/`,`n/`,`p/`,`r/`,`t/`) to prevent parsing errors. For instance, `a/lemontree street t/1` may cause the command to fail, as the system will interpret `t/` as an unintended tag prefix.
     * Example: `a/6 College Ave West`
 * `FAMILY`: Immediate family size
-    * It should be an integer greater than 1.
+    * It should be an integer greater than 0.
     * Value should not contain decimal points as this is not expected for whole number type data, a simple workaround is
       to simply avoid the use of decimals.
     * Example: `f/4`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -374,7 +374,9 @@ calculated by the number of days until their next birthday relative to the curre
 - The current date is based on the local system's time.
 - If their birthday has already passed, the calculation is based on the number of days until their next birthday next year.
 - If the list presented is currently a filtered list after using `filter`, sort will work on the new filtered list.
-- If a birthday falls on February 29th (leap day), the day calculation is based on March 1st if the year does not have a leap date.
+- If a birthday falls on February 29th (leap day),
+  the day calculation is based on March 1st if the year does not have a leap date
+  as realistically, most would still celebrate every year.
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -402,8 +404,7 @@ Shows the help message for the specified command only.
 
 - Note that this feature is only available for the `add`,`clearRealodex`,`delete`,`edit`,`filter`,`list` and `sort` commands.
 - Although the format is `COMMAND help`, the exception is the help message for the clear command. Use `clear help` instead of `clearRealodex help`.
-  <br>Exception also includes `help` command where `help help` will simply open up the window as expected
-      and `exit` command where `exit help` will simply exit the application as expected.
+  <br>Any other valid command followed by `help` that is not included in this feature will simply execute the command as per normal.
 
 <u>Examples:</u>
 <p align="center">

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -27,7 +27,7 @@ If you can type fast, Realodex can get your contact management tasks done faster
 command to run the application.<br>
    A GUI similar to the below should appear in a few seconds. The app should contain some sample entries.<br>
    <a href="images/Ui.png">
-   <img src="images/Ui.png" alt="Ui Image" style="width:80%">
+   <img src="images/Ui.png" alt="Ui Image" style="width:50%">
    </a>
 
 1. Some example commands you can try:
@@ -38,7 +38,10 @@ command to run the application.<br>
    * `delete n/john doe` : Deletes the client with name `John Doe` from Realodex.
 
 1. Refer to the [Features](#features) below for details of each command.
-----
+--------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
+
 # Using this Guide
 
 To ensure you have a smooth and intuitive experience, this guide utilizes specific formatting conventions and icons. Familiarizing yourself with these will enhance your understanding and efficiency as you navigate through the functionalities of Realodex.
@@ -72,9 +75,9 @@ To ensure you have a smooth and intuitive experience, this guide utilizes specif
 | Case-Sensitive                 | The casing of the alphabetic characters matters (e.g. “ReAlOdEx” is different from “realodex”                                                                                                            |
 | Case-Insensitive               | The casing of the alphabetic characters does not matter (e.g. “ReAlOdEx” is taken to be same as “realodex”                                                                                               |
 
----
-
 --------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
 
 ## Features
 
@@ -103,6 +106,10 @@ To ensure you have a smooth and intuitive experience, this guide utilizes specif
 
 
 </box>
+
+--------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
 
 ### Adding a client: `add`
 
@@ -142,6 +149,10 @@ Adds a client to Realodex.
 * `add n/John Doe p/98765432 i/20000 e/johnd@example.com a/311, Clementi Ave 2, #02-25 f/4 t/Buyer h/HDB r/Owes $1000. b/27May2003`
 * `add n/Betsy Crowe a/Newgate Prison i/0 f/1 p/94859694 e/betsyc@rocketmail.com t/Seller h/CONDOMINIUM t/Buyer`
 
+--------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
+
 ### Deleting a client : `delete`
 
 Deletes the specified client from Realodex. There are 2 ways to do so:
@@ -177,6 +188,11 @@ Errors:
 - If neither index nor name is provided `delete` will show an error message "Please provide either an index or a name."
 - If both an index and name is provided `delete INDEX n/NAME` will show an error message "Please provide either an index or a name, not both."
 - If both an index and name is provided `delete n/NAME INDEX ` will show an error message "The client name provided is invalid" as INDEX is considered part of the NAME."
+
+--------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
+
 ### Editing clients : `edit`
 
 Edits specified details of the client.
@@ -201,6 +217,10 @@ Edits specified details of the client.
 
 - `edit 1 p/999` will overwrite the 1st client's phone number to "999".
 - `edit 2 n/Kylie  i/3333 f/5` will overwrite the 2nd client's name to "Kylie", income to "3333" and family size to "5".
+
+--------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
 
 ### Filtering clients: `filter`
 
@@ -332,11 +352,14 @@ This is an intentional design choice to ensure that the command is used for targ
   <em> <code>filter b/Apr</code> returns persons with Birthday in April</em>
 </p>
 
+--------------------------------------------------------------------------------------------------------------------
+
 ### Listing clients : `list`
 
 Lists all clients in Realodex.
 
 <u>Format:</u> `list`
+
 
 ### Sort : `sort`
 
@@ -350,6 +373,7 @@ calculated by the number of days until their next birthday relative to the curre
 - If the list presented is currently a filtered list after using `filter`, sort will work on the new filtered list.
 - If a birthday falls on February 29th (leap day), the day calculation is based on March 1st if the year does not have a leap date.
 
+--------------------------------------------------------------------------------------------------------------------
 
 ### Clearing Realodex : `clearRealodex`
 
@@ -390,6 +414,8 @@ Exits the program.
 <u>Format:</u> `exit`
 - Note that keying in `exit` followed by any random string, such as `exit wrelvwrvn` will also cause the app to exit.
 
+--------------------------------------------------------------------------------------------------------------------
+
 ### File Data
 
 The JSON file that stores the data of your contacts can be found in a folder named `data`, in the same folder/directory as the Realodex app. (e.g. if you
@@ -416,6 +442,9 @@ Should you want to re-enter your contacts in a fresh JSON file in the event of f
 simply delete `realodex.json`, which can be found in the `data` folder, and restart the app. A new JSON file with sample contacts will be generated and you may proceed from there.
 
 --------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
+
 ## Field Constraints
 * `NAME`:
     * Should only contain Alphanumeric characters and must be unique.
@@ -479,6 +508,9 @@ simply delete `realodex.json`, which can be found in the `data` folder, and rest
     5. The year "YYYY" must be in full and greater than or equal to 1000. (`b/29Feb02` is not allowed)
 
 --------------------------------------------------------------------------------------------------------------------
+
+<div style="page-break-after: always;"></div>
+
 ## Command summary
 
 | Action                         | Format, Examples                                                                                                                                                                                                                                |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -164,15 +164,19 @@ Deletes the specified client from Realodex. There are 2 ways to do so:
 * Deletes the client of the specified `INDEX` in Realodex.
 * 💡 If you are currently filtered, the index will be based on the filtered list.
 * If `INDEX` is **more than the number of clients in Realodex**, error message will be shown "The client index provided is invalid."
-* If 'INDEX` is a non-zero unsigned integer, error message will be shown "Index is not a non-zero unsigned integer."
+  to indicate that this client index does not exist.
+  * This does not apply to unrealistic index values of >= `2147483648` which results in integer overflow as expected
+     and will no longer be interpreted as a non-zero unsigned integer.
+    Hence, below error message applies.
+* If `INDEX` is a **non-zero unsigned integer**, error message will be shown "Index is not a non-zero unsigned integer."
 
 <u>Example</u>:
 * `delete 4` deletes the 4th client listed in Realodex, provided there are 4 or more entries.
 
 Errors:
-- If neither index nor name is provided `delete` will show an error message "Please provide either an index or a name.".
-- If both an index and name is provided `delete INDEX n/NAME` will show an error message "Please provide either an index or a name, not both.".
-- If both an index and name is provided `delete n/NAME INDEX ` will show an error message "The client name provided is invalid" as INDEX is considered part of the NAME".
+- If neither index nor name is provided `delete` will show an error message "Please provide either an index or a name."
+- If both an index and name is provided `delete INDEX n/NAME` will show an error message "Please provide either an index or a name, not both."
+- If both an index and name is provided `delete n/NAME INDEX ` will show an error message "The client name provided is invalid" as INDEX is considered part of the NAME."
 ### Editing clients : `edit`
 
 Edits specified details of the client.
@@ -180,8 +184,14 @@ Edits specified details of the client.
 <u>Format</u>: `edit INDEX [n/NAME] [p/PHONE] [i/INCOME] [e/EMAIL] [a/ADDRESS] [f/FAMILY] [t/TAG] [h/HOUSINGTYPE] [r/REMARK] [b/BIRTHDAY]`
 
 - If `INDEX` is `3`, the 3rd client's information will be edited.
-- 💡 If you are currently filtered, the index will be based on the filtered list.
-- It is optional to edit any field (i.e, you can choose to edit any combination of fields so long there is at least 1).
+- If `INDEX` is **more than the number of clients in Realodex**, error message will be shown "The client index provided is invalid."
+    to indicate that this client index does not exist.
+  * This does not apply to unrealistic index values of >= `2147483648` which results in integer overflow as expected
+    and will no longer be interpreted as a non-zero unsigned integer.
+    Hence, below error message applies.
+- If `INDEX` is a **non-zero unsigned integer**, error message will be shown "Invalid command format..."
+- 💡 If you currently have a filtered list present, the index will be based on the filtered list.
+- It is optional to edit any field (i.e, you can choose to edit any combination of fields so long there is **at least 1**).
 - The current information will be overwritten with the input provided.
 - When editing the `TAG`, all existing tags will be overwritten with the new tag(s) provided. If you want to edit the client to be both a buyer and seller, include both tags i.e. `t/Buyer t/Seller`.
 - All fields must follow the respective [Field Constraints](#field-constraints).
@@ -399,19 +409,21 @@ simply delete `realodex.json`, which can be found in the `data` folder, and rest
 
 --------------------------------------------------------------------------------------------------------------------
 ## Field Constraints
-* NAME:
+* `NAME`:
     * Should only contain Alphanumeric characters and must be unique.
-    1. Names are case-insensitive.
+    1. While we disallow `s/o` as `/` is used as a command delimiter, a simple and reasonable work-around for this 
+       until it is supported, is to use a workaround such as using `s o` or `son of`).
+  2. Names are case-insensitive.
   2. Number of spaces between words in the name do not matter.
   3. Although names are displayed in full capitalisation, they are still recorded in a case-insensitive manner. Hence, an input with the same name but different capitalisation will be considered a duplicate entry.
     * Example: `n/John Doe` and `n/john   doe` are both considered the same valid name but both will be displayed as `JOHN DOE`.
-* PHONE:
+* `PHONE`:
     * Should only contain numbers, and should be at least 3 digits long.
     * Example: `p/81234567`
-* INCOME:
+* `INCOME`:
     * Income should be an integer and should be at least 0.
     * Example: `i/20000`
-* EMAIL:
+* `EMAIL`:
     * Emails should be of the format local-part@domain and adhere to the following constraints:
     1. The local-part should only contain alphanumeric characters and these special characters, excluding the parentheses, (+_.-).
     2. The local-part may not start or end with any special characters.
@@ -421,23 +433,25 @@ simply delete `realodex.json`, which can be found in the `data` folder, and rest
         * have each domain label start and end with alphanumeric characters
         * have each domain label consist of alphanumeric characters, separated only by hyphens, if any.
     * Example: `e/realodex-admin@gmail.com`
-* ADDRESS: Current residential address
+* `ADDRESS`: Current residential address
     * Must not include other command prefixes (`a/`,`b/`,`e/`,`f/`,`h/`,`i/`,`n/`,`p/`,`r/`,`t/`) to prevent parsing errors. For instance, `a/lemontree street t/1` may cause the command to fail, as the system will interpret `t/` as an unintended tag prefix.
     * Example: `a/6 College Ave West`
-* FAMILY: Immediate family size
-    * Should be an integer greater than 1.
+* `FAMILY`: Immediate family size
+    * It should be an integer greater than 1.
+    * Value should not contain decimal points as this is not expected for whole number type data, a simple workaround is
+      to simply avoid the use of decimals.
     * Example: `f/4`
-* TAG:
+* `TAG`:
     * Only accept "buyer" or "seller" as the input (case-insensitive). Multiple tags are accepted.
     * Example: `t/buyer`, `t/seller` or both
-* HOUSINGTYPE: housing type a buyer wants or housing type a seller is selling
+* `HOUSINGTYPE`: housing type a buyer wants or housing type a seller is selling
     * Must be one of the following: "HDB", "CONDOMINIUM", "LANDED PROPERTY", "GOOD CLASS BUNGALOW" (case-insensitive). Only one housing type is allowed.
     * Example: `h/HDB`
-* REMARK:
+* `REMARK`:
     * Can be empty if remark is not specified.
     * Must not include other command prefixes (`a/`, `b/`, `f/`, `h/`, `i/`, `n/`, `p/`, `r/`, `t/`) to prevent parsing errors. For instance, `r/Prefers block b/c` may cause the command to fail, as the system will interpret `b/` as an unintended birthday prefix.
     * Example: `r/Has a cat`
-* BIRTHDAY:
+* `BIRTHDAY`:
     * Should be in the form "DDMMMYYYY", and can be empty if the birthday is not specified.
     * Example: `b/22Feb2002`
     1. The date must not be in the future.

--- a/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
@@ -38,6 +38,11 @@ import seedu.realodex.model.person.Tag;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
+    public static final Prefix[] COMPULSORY_PREFIXES =
+            new Prefix[]{PREFIX_NAME, PREFIX_ADDRESS, PREFIX_INCOME, PREFIX_PHONE,
+                PREFIX_FAMILY, PREFIX_EMAIL,
+                PREFIX_TAG, PREFIX_HOUSINGTYPE};
+
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
@@ -77,11 +82,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException If any compulsory prefix is missing.
      */
     private void validateCompulsoryPrefixes(ArgumentMultimap argMultimap) throws ParseException {
-        Prefix[] compulsoryPrefixes = {PREFIX_NAME, PREFIX_ADDRESS, PREFIX_INCOME, PREFIX_PHONE,
-            PREFIX_FAMILY, PREFIX_EMAIL,
-            PREFIX_TAG, PREFIX_HOUSINGTYPE};
-        if (!arePrefixesPresent(argMultimap, compulsoryPrefixes)) {
-            String missingPrefixesMessage = argMultimap.returnMessageOfMissingPrefixes(compulsoryPrefixes) + "\n";
+        if (!arePrefixesPresent(argMultimap, COMPULSORY_PREFIXES)) {
+            String missingPrefixesMessage = argMultimap.returnMessageOfMissingPrefixes(COMPULSORY_PREFIXES) + "\n";
             throw new ParseException(Messages.getErrorMessageForMissingPrefixes(missingPrefixesMessage)
                                              + AddCommand.MESSAGE_USAGE);
         }

--- a/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/AddCommandParser.java
@@ -122,13 +122,17 @@ public class AddCommandParser implements Parser<AddCommand> {
                                                    .getValueOrDefault(PREFIX_BIRTHDAY)
                                                    .orElseThrow());
         birthdayStored.buildErrorMessage(errorMessageBuilder, "birthday");
+        handleErrorMessage(errorMessageBuilder);
 
-        if (errorMessageBuilder.length() > 0) {
-            throw new ParseException(errorMessageBuilder.toString().trim());
-        }
         Birthday birthday = birthdayStored.returnStoredResult();
 
         return new Person(name, phone, income, email, address, family, tags, housingType, remark, birthday);
+    }
+
+    private void handleErrorMessage(StringBuilder errorMessageBuilder) throws ParseException {
+        if (errorMessageBuilder.length() > 0) {
+            throw new ParseException(errorMessageBuilder.toString().trim());
+        }
     }
 
     // Methods for parsing individual fields

--- a/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/realodex/logic/parser/EditCommandParser.java
@@ -89,15 +89,23 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setRemark(ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()));
         }
 
+        handleErrorMessage(errorMessageBuilder);
+
+        checkIfAnyFieldEdited(editPersonDescriptor);
+
+        return editPersonDescriptor;
+    }
+
+    private void handleErrorMessage(StringBuilder errorMessageBuilder) throws ParseException {
         if (errorMessageBuilder.length() > 0) {
             throw new ParseException(errorMessageBuilder.toString());
         }
+    }
 
+    private void checkIfAnyFieldEdited(EditPersonDescriptor editPersonDescriptor) throws ParseException {
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
-
-        return editPersonDescriptor;
     }
 
     private <T> void parseAndSetField(ArgumentMultimap argMultimap, Prefix prefix, Consumer<T> setter,

--- a/src/main/java/seedu/realodex/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/realodex/logic/parser/ParserUtil.java
@@ -239,7 +239,6 @@ public class ParserUtil {
         if (!Family.isValidFamily(trimmedFamily)) {
             throw new ParseException(Family.MESSAGE_CONSTRAINTS);
         }
-        assert Integer.parseInt(trimmedFamily) >= 1;
         return new Family(trimmedFamily);
     }
 
@@ -257,7 +256,6 @@ public class ParserUtil {
         if (!Family.isValidFamily(trimmedFamily)) {
             return new ParserUtilResult<>(Family.MESSAGE_CONSTRAINTS, new Family());
         }
-        assert Integer.parseInt(trimmedFamily) >= 1;
         return new ParserUtilResult<>("", new Family(trimmedFamily));
     }
 

--- a/src/main/java/seedu/realodex/model/person/Address.java
+++ b/src/main/java/seedu/realodex/model/person/Address.java
@@ -16,6 +16,7 @@ public class Address {
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String DEFAULT_ADDRESS = "Woodlands";
 
     public final String value;
 
@@ -31,7 +32,7 @@ public class Address {
     }
 
     public Address() {
-        value = "Woodlands";
+        value = DEFAULT_ADDRESS;
     }
 
     /**

--- a/src/main/java/seedu/realodex/model/person/Email.java
+++ b/src/main/java/seedu/realodex/model/person/Email.java
@@ -23,7 +23,9 @@ public class Email {
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "(" + "[" + SPECIAL_CHARACTERS + "]"
+    private static final String LOCAL_PART_REGEX = "^"
+            + ALPHANUMERIC_NO_UNDERSCORE + "("
+            + "[" + SPECIAL_CHARACTERS + "]"
             + "*" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
 
 

--- a/src/main/java/seedu/realodex/model/person/Email.java
+++ b/src/main/java/seedu/realodex/model/person/Email.java
@@ -34,6 +34,7 @@ public class Email {
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    private static final String DEFAULT_EMAIL = "denzel@gmail.com";
 
     public final String value;
 
@@ -49,7 +50,7 @@ public class Email {
     }
 
     public Email() {
-        value = "denzel@gmail.com";
+        value = DEFAULT_EMAIL;
     }
 
     /**

--- a/src/main/java/seedu/realodex/model/person/Email.java
+++ b/src/main/java/seedu/realodex/model/person/Email.java
@@ -23,8 +23,10 @@ public class Email {
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "(" + "[" + SPECIAL_CHARACTERS + "]"
+            + "*" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+
+
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars

--- a/src/main/java/seedu/realodex/model/person/Family.java
+++ b/src/main/java/seedu/realodex/model/person/Family.java
@@ -11,7 +11,7 @@ public class Family {
 
     /** Message for constraints on family size. */
     public static final String MESSAGE_CONSTRAINTS = "Family size should be at least 1";
-    public static final String VALIDATION_REGEX = "^\\d+$";
+    public static final String VALIDATION_REGEX = "^0*[1-9]\\d*$";
 
     /** The family size. */
     private String familySize;

--- a/src/main/java/seedu/realodex/model/person/Family.java
+++ b/src/main/java/seedu/realodex/model/person/Family.java
@@ -3,8 +3,6 @@ package seedu.realodex.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.realodex.commons.util.AppUtil.checkArgument;
 
-import java.util.Objects;
-
 /**
  * Represents the family size of a person in realodex.
  * Guarantees: family size is present and not null, and adheres to specific constraints.
@@ -42,7 +40,7 @@ public class Family {
      */
     public static boolean isValidFamily(String familySize) {
         // Ensure the family size matches the validation regex
-        if (!familySize.matches(VALIDATION_REGEX) ) {
+        if (!familySize.matches(VALIDATION_REGEX)) {
             return false;
         }
         return !familySize.equals("0");

--- a/src/main/java/seedu/realodex/model/person/Family.java
+++ b/src/main/java/seedu/realodex/model/person/Family.java
@@ -12,6 +12,7 @@ public class Family {
     /** Message for constraints on family size. */
     public static final String MESSAGE_CONSTRAINTS = "Family size should be at least 1";
     public static final String VALIDATION_REGEX = "^0*[1-9]\\d*$";
+    public static final String DEFAULT_FAMILY = "1";
 
     /** The family size. */
     private String familySize;
@@ -29,7 +30,7 @@ public class Family {
     }
 
     public Family() {
-        this.familySize = "1";
+        this.familySize = DEFAULT_FAMILY;
     }
 
     /**

--- a/src/main/java/seedu/realodex/model/person/Family.java
+++ b/src/main/java/seedu/realodex/model/person/Family.java
@@ -3,6 +3,8 @@ package seedu.realodex.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.realodex.commons.util.AppUtil.checkArgument;
 
+import java.util.Objects;
+
 /**
  * Represents the family size of a person in realodex.
  * Guarantees: family size is present and not null, and adheres to specific constraints.
@@ -11,7 +13,7 @@ public class Family {
 
     /** Message for constraints on family size. */
     public static final String MESSAGE_CONSTRAINTS = "Family size should be at least 1";
-    public static final String VALIDATION_REGEX = "^[1-9]\\d*$";
+    public static final String VALIDATION_REGEX = "^\\d+$";
 
     /** The family size. */
     private String familySize;
@@ -39,7 +41,11 @@ public class Family {
      * @return True if the family size is greater than or equal to zero, false otherwise.
      */
     public static boolean isValidFamily(String familySize) {
-        return familySize.matches(VALIDATION_REGEX);
+        // Ensure the family size matches the validation regex
+        if (!familySize.matches(VALIDATION_REGEX) ) {
+            return false;
+        }
+        return !familySize.equals("0");
     }
 
     /**

--- a/src/main/java/seedu/realodex/model/person/HousingType.java
+++ b/src/main/java/seedu/realodex/model/person/HousingType.java
@@ -12,6 +12,7 @@ public class HousingType {
     public static final String MESSAGE_CONSTRAINTS = "Housing type should be either 'HDB', 'CONDOMINIUM', "
             + "'LANDED PROPERTY' or 'GOOD CLASS BUNGALOW'";
     public static final String VALIDATION_REGEX = "[\\p{Alnum} ]+";
+    public static final House DEFAULT_HOUSE = House.HDB;
     private House housingType;
 
     /**
@@ -33,7 +34,7 @@ public class HousingType {
     }
 
     public HousingType() {
-        this.housingType = House.HDB;
+        this.housingType = DEFAULT_HOUSE;
     }
 
     /**

--- a/src/main/java/seedu/realodex/model/person/Income.java
+++ b/src/main/java/seedu/realodex/model/person/Income.java
@@ -12,7 +12,7 @@ public class Income {
     /** Message for constraints on income. */
     public static final String MESSAGE_CONSTRAINTS = "Income should be an integer and should be at least 0";
     public static final String VALIDATION_REGEX = "^[0-9]+$";
-    public static final String DEFAULT_INCOME = "1";
+    public static final String DEFAULT_INCOME = "0";
 
     /** The income value. */
     private final String incomeValue;

--- a/src/main/java/seedu/realodex/model/person/Income.java
+++ b/src/main/java/seedu/realodex/model/person/Income.java
@@ -12,6 +12,7 @@ public class Income {
     /** Message for constraints on income. */
     public static final String MESSAGE_CONSTRAINTS = "Income should be an integer and should be at least 0";
     public static final String VALIDATION_REGEX = "^[0-9]+$";
+    public static final String DEFAULT_INCOME = "1";
 
     /** The income value. */
     private final String incomeValue;
@@ -28,7 +29,7 @@ public class Income {
     }
 
     public Income() {
-        this.incomeValue = "1";
+        this.incomeValue = DEFAULT_INCOME;
     }
 
     /**

--- a/src/main/java/seedu/realodex/model/person/Name.java
+++ b/src/main/java/seedu/realodex/model/person/Name.java
@@ -17,10 +17,11 @@ public class Name {
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String DEFAULT_NAME = "Denzel";
 
     public final String fullName;
 
-    private final String defaultValidName = "Denzel";
+    private final String defaultValidName = DEFAULT_NAME;
 
     /**
      * Constructs a {@code Name}.

--- a/src/main/java/seedu/realodex/model/person/Phone.java
+++ b/src/main/java/seedu/realodex/model/person/Phone.java
@@ -13,6 +13,7 @@ public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
     public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String DEFAULT_PHONE = "999";
     public final String value;
 
     /**
@@ -27,7 +28,7 @@ public class Phone {
     }
 
     public Phone() {
-        value = "1";
+        value = DEFAULT_PHONE;
     }
 
     /**

--- a/src/main/java/seedu/realodex/model/person/Phone.java
+++ b/src/main/java/seedu/realodex/model/person/Phone.java
@@ -13,7 +13,7 @@ public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
     public static final String VALIDATION_REGEX = "\\d{3,}";
-    public static final String DEFAULT_PHONE = "999";
+    public static final String DEFAULT_PHONE = "88888888";
     public final String value;
 
     /**

--- a/src/test/java/seedu/realodex/model/person/EmailTest.java
+++ b/src/test/java/seedu/realodex/model/person/EmailTest.java
@@ -44,7 +44,6 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
@@ -64,6 +63,64 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+
+
+        assertTrue(Email.isValidEmail("u+++u@gmail.com")); // multiple consecutive special characters
+        assertTrue(Email.isValidEmail("test..email@example.com")); // consecutive periods
+        assertTrue(Email.isValidEmail("john.doe+test@example.com")); // consecutive special characters with alphanumeric characters
+
+        assertTrue(Email.isValidEmail("a+b@example.com")); // '+' symbol in local-part
+        assertTrue(Email.isValidEmail("a_b@example.com")); // '_' symbol in local-part
+        assertTrue(Email.isValidEmail("a-b@example.com")); // '-' symbol in local-part
+        assertTrue(Email.isValidEmail("a.b@example.com")); // '.' symbol in local-part
+
+        assertTrue(Email.isValidEmail("user@localhost")); // localhost domain
+        assertTrue(Email.isValidEmail("user@sub.domain.example.com")); // subdomains
+
+        assertTrue(Email.isValidEmail("user@example.co.uk")); // UK top-level domain
+        assertTrue(Email.isValidEmail("user@example.travel")); // .travel top-level domain
+        assertTrue(Email.isValidEmail("user@example.museum")); // .museum top-level domain
+
+        assertTrue(Email.isValidEmail("peter_jack+1190@example.com")); // mixture of alphanumeric and special characters
+        assertTrue(Email.isValidEmail("user1@example.com")); // numeric local-part
+        assertTrue(Email.isValidEmail("user1@example1.com")); // numeric domain name
+
+
+        // additional symbols that are not supported
+        assertFalse(Email.isValidEmail("user%name@example.com")); // '%'
+        assertFalse(Email.isValidEmail("user!name@example.com")); // '!'
+        assertFalse(Email.isValidEmail("user#name@example.com")); // '#'
+        assertFalse(Email.isValidEmail("user$name@example.com")); // '$'
+        assertFalse(Email.isValidEmail("user^name@example.com")); // '^'
+        assertFalse(Email.isValidEmail("user&name@example.com")); // '&'
+        assertFalse(Email.isValidEmail("user*name@example.com")); // '*'
+        assertFalse(Email.isValidEmail("user=name@example.com")); // '='
+        assertFalse(Email.isValidEmail("user?name@example.com")); // '?'
+
+        // consecutive symbols
+        assertTrue(Email.isValidEmail("user..name@example.com")); // consecutive periods
+        assertTrue(Email.isValidEmail("user__name@example.com")); // consecutive underscores
+        assertTrue(Email.isValidEmail("user--name@example.com")); // consecutive hyphens
+        assertTrue(Email.isValidEmail("user++name@example.com")); // consecutive pluses
+
+        // long email addresses
+        assertTrue(Email.isValidEmail("a".repeat(64) + "@example.com")); // local-part of 64 characters
+        assertTrue(Email.isValidEmail("user." + "example".repeat(63) + "@example.com")); // domain label of 63 characters
+        assertTrue(Email.isValidEmail("user@example." + "com".repeat(63))); // top-level domain of 63 characters
+
+        // mixed valid characters
+        assertTrue(Email.isValidEmail("u_ser+name@example.com")); // mixed alphanumeric and '+'
+        assertTrue(Email.isValidEmail("user_name@example.com")); // mixed alphanumeric and '_'
+        assertTrue(Email.isValidEmail("use.rname@example.com")); // mixed alphanumeric and '.'
+        assertTrue(Email.isValidEmail("user-name@example.com")); // mixed alphanumeric and '-'
+        assertTrue(Email.isValidEmail("user@name.example.com")); // mixed alphanumeric and '.' (domain part)
+
+        // consecutive mixed valid characters
+        assertTrue(Email.isValidEmail("us..er+name@example.com")); // mixed consecutive periods and '+'
+        assertTrue(Email.isValidEmail("use_.rname@example.com")); // mixed consecutive underscores and '_'
+        assertTrue(Email.isValidEmail("us.er+-name@example.com")); // mixed consecutive period and hyphens and '-'
+        assertTrue(Email.isValidEmail("user-.n+++++++++++-----------ame@example.com")); // mixed consecutive periods and
+        // '.'
     }
 
     @Test

--- a/src/test/java/seedu/realodex/model/person/EmailTest.java
+++ b/src/test/java/seedu/realodex/model/person/EmailTest.java
@@ -125,7 +125,6 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("use_.rname@example.com")); // mixed consecutive underscores and '_'
         assertTrue(Email.isValidEmail("us.er+-name@example.com")); // mixed consecutive period and hyphens and '-'
         assertTrue(Email.isValidEmail("user-.n+++++++++++-----------ame@example.com")); // mixed consecutive periods and
-        // '.'
     }
 
     @Test

--- a/src/test/java/seedu/realodex/model/person/EmailTest.java
+++ b/src/test/java/seedu/realodex/model/person/EmailTest.java
@@ -67,7 +67,8 @@ public class EmailTest {
 
         assertTrue(Email.isValidEmail("u+++u@gmail.com")); // multiple consecutive special characters
         assertTrue(Email.isValidEmail("test..email@example.com")); // consecutive periods
-        assertTrue(Email.isValidEmail("john.doe+test@example.com")); // consecutive special characters with alphanumeric characters
+        // consecutive special characters with alphanumeric characters
+        assertTrue(Email.isValidEmail("john.doe+test@example.com"));
 
         assertTrue(Email.isValidEmail("a+b@example.com")); // '+' symbol in local-part
         assertTrue(Email.isValidEmail("a_b@example.com")); // '_' symbol in local-part
@@ -104,9 +105,13 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("user++name@example.com")); // consecutive pluses
 
         // long email addresses
-        assertTrue(Email.isValidEmail("a".repeat(64) + "@example.com")); // local-part of 64 characters
-        assertTrue(Email.isValidEmail("user." + "example".repeat(63) + "@example.com")); // domain label of 63 characters
-        assertTrue(Email.isValidEmail("user@example." + "com".repeat(63))); // top-level domain of 63 characters
+        assertTrue(Email.isValidEmail("a".repeat(64)
+                                              + "@example.com")); // local-part of 64 characters
+        assertTrue(Email.isValidEmail("user."
+                                              + "example".repeat(63)
+                                              + "@example.com")); // domain label of 63 characters
+        assertTrue(Email.isValidEmail("user@example."
+                                              + "com".repeat(63))); // top-level domain of 63 characters
 
         // mixed valid characters
         assertTrue(Email.isValidEmail("u_ser+name@example.com")); // mixed alphanumeric and '+'

--- a/src/test/java/seedu/realodex/model/person/FamilyTest.java
+++ b/src/test/java/seedu/realodex/model/person/FamilyTest.java
@@ -52,6 +52,11 @@ public class FamilyTest {
         assertTrue(Family.isValidFamily("1")); // Minimum valid value
         assertTrue(Family.isValidFamily("123")); // Positive integer
         assertTrue(Family.isValidFamily("999999999999999")); // Large positive integer
+        assertTrue(Family.isValidFamily("01")); // Prepended 0s
+        assertTrue(Family.isValidFamily("001")); // Double prepended 0s
+        assertTrue(Family.isValidFamily("0001")); // Three prepended 0s
+        assertTrue(Family.isValidFamily("00000000000000000000000000001")); // Many prepended 0s
+        assertTrue(Family.isValidFamily("01232132131313312313131")); // Single prepended 0 with large value
     }
 
 

--- a/src/test/java/seedu/realodex/model/person/FamilyTest.java
+++ b/src/test/java/seedu/realodex/model/person/FamilyTest.java
@@ -40,6 +40,22 @@ public class FamilyTest {
     }
 
     @Test
+    public void isValidFamily_invalidFamilySizes_returnsFalse() {
+        assertFalse(Family.isValidFamily("")); // Empty string
+        assertFalse(Family.isValidFamily(" ")); // Whitespace string
+        assertFalse(Family.isValidFamily("-1")); // Negative number
+        assertFalse(Family.isValidFamily("0")); // Zero
+    }
+
+    @Test
+    public void isValidFamily_validFamilySizes_returnsTrue() {
+        assertTrue(Family.isValidFamily("1")); // Minimum valid value
+        assertTrue(Family.isValidFamily("123")); // Positive integer
+        assertTrue(Family.isValidFamily("999999999999999")); // Large positive integer
+    }
+
+
+    @Test
     public void equals() {
         Family family = new Family("999");
 

--- a/src/test/java/seedu/realodex/model/person/FamilyTest.java
+++ b/src/test/java/seedu/realodex/model/person/FamilyTest.java
@@ -57,6 +57,11 @@ public class FamilyTest {
         assertTrue(Family.isValidFamily("0001")); // Three prepended 0s
         assertTrue(Family.isValidFamily("00000000000000000000000000001")); // Many prepended 0s
         assertTrue(Family.isValidFamily("01232132131313312313131")); // Single prepended 0 with large value
+
+
+        assertFalse(Family.isValidFamily("0000000000000000000000000000")); // Many prepended 0s with no 1-9 value
+        assertFalse(Family.isValidFamily("-0000000000000000000000000000")); // - + Many prepended 0s with no 1-9 value
+        assertFalse(Family.isValidFamily("-0000000000000000000010000000")); // - + Many prepended 0s with some 1-9 value
     }
 
 


### PR DESCRIPTION
- Family now allows prepended '0's and integer overflows (interprets as string)
Rationale:
I believe not allowing prepended 0s is a strictly incorrect behaviour that deviates from our expected behaviour to allow such values and this is due to our error in validation code and regex, we are using asserts and parseInt which causes such errors
This follows the Q&A of 

![image](https://github.com/AY2324S2-CS2103T-W10-1/tp/assets/39399745/d0fc53c9-0255-4310-86fe-2479795aea67)


`public static final String VALIDATION_REGEX = "^0*[1-9]\\d*$";` is the new regex that does not omit starting 0s as expected.

- `EMAIL` regex also fixed as it differs from advertised behaviour to accept continuous symbols but originally it does not. Tests added but pls check yourself too


UG now 
- makes index parsing clearer, for overflow and negative what errors are shown, shown in delete and edit separately
- family should be without decimals
- phone number should be without spaces and symbols
- Added extraneous filter birthday month documentation
- `sort` describes how leap birthdays are handled.
- Add documentation to justify non compulsory top level domain for emails

Please also help to check if the issues tagged are relevant thanks

Fix #259
Fix #244
Fix #272
Fix #278 
Fix #267
Fix #249
Fix #247
Fix #260
Fix #264